### PR TITLE
auto update indicator in the atom://about page

### DIFF
--- a/lib/about.coffee
+++ b/lib/about.coffee
@@ -21,3 +21,11 @@ module.exports = About =
 
   deactivate: ->
     @subscriptions.dispose()
+
+  consumeStatusBar: (statusBar) ->
+    return unless atom.isReleasedVersion()
+
+    previousVersion = localStorage.getItem('release-notes:previousVersion')
+    localStorage.setItem('release-notes:previousVersion', atom.getVersion())
+    ReleaseNoteStatusBar = require './release-notes-status-bar'
+    new ReleaseNoteStatusBar(statusBar, previousVersion)

--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -1,0 +1,24 @@
+{View} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
+shell = require('shell')
+
+module.exports =
+class ReleaseNotesStatusBar extends View
+  @content: ->
+    @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block'
+
+  initialize: (@statusBar, previousVersion) ->
+    @subscriptions = new CompositeDisposable()
+
+    @on 'click', ->
+      shell.openExternal 'https://atom.io/releases'
+    @subscriptions.add atom.commands.add 'atom-workspace', 'window:update-available', => @attach()
+
+    @subscriptions.add atom.tooltips.add(@element, title: 'Click to view the release notes')
+    @attach() if previousVersion? and previousVersion isnt atom.getVersion()
+
+  attach: ->
+    @statusBar.addRightTile(item: this, priority: -100)
+
+  detached: ->
+    @subscriptions?.dispose()

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.5"
   },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
+      }
+    }
+  },
   "devDependencies": {
     "coffeelint": "^1.9.7"
   }

--- a/styles/about.less
+++ b/styles/about.less
@@ -1,5 +1,6 @@
 @import "ui-variables";
 @import "variables";
+@import "three";
 
 .about {
   display: flex;
@@ -63,6 +64,8 @@
     }
 
     .about-version-container {
+      vertical-align: middle;
+
       &:hover {
         color: lighten(@text-color, 15%);
       }
@@ -72,6 +75,7 @@
       }
       .about-version {
         margin-right: 8px;
+        margin-left: 8px;
       }
 
       // TODO: Remove copy icon from normal flow so its width won't be used when
@@ -82,12 +86,19 @@
           // The copy octicon hangs too low without bumping it up a bit
           position: relative;
           bottom: 1px;
+          margin-right: 7px;
         }
-
       }
 
-    }
+      .update-checked{
+          -webkit-transition: opacity 1s;
+          opacity: 0;
+      }
 
+      .update-checked.updated {
+          opacity: 1.0;
+      }
+    }
     button {
       font-size: 1em;
     }
@@ -98,7 +109,7 @@
   }
 
   .about-actions {
-    margin-top: 3em;
+    margin-top: 1.5em;
     font-size: .86em;
     text-align: center;
   }

--- a/styles/three.less
+++ b/styles/three.less
@@ -1,0 +1,65 @@
+//From https://github.com/jlong/css-spinners.git
+@import "variables";
+
+@three-quarters-loader-size: 1.2em;
+@three-quarters-loader-color: @atom-green;
+
+@-moz-keyframes three-quarters-loader {
+  0% {
+    -moz-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -moz-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes three-quarters-loader {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes three-quarters-loader {
+  0% {
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+/* :not(:required) hides this rule from IE9 and below */
+.three-quarters-loader:not(:required) {
+  -moz-animation: three-quarters-loader 1250ms infinite linear;
+  -webkit-animation: three-quarters-loader 1250ms infinite linear;
+  animation: three-quarters-loader 1250ms infinite linear;
+  border: (@three-quarters-loader-size/4) solid (@three-quarters-loader-color);
+  border-right-color: transparent;
+  border-radius: (@three-quarters-loader-size/2);
+  box-sizing: border-box;
+  display: inline-block;
+  position: absolute;
+  text-align: center;
+  overflow: hidden;
+  text-indent: -9999px;
+  width: @three-quarters-loader-size;
+  height: @three-quarters-loader-size;
+  // vertical-align: middle;
+  text-align: right;
+  opacity: 1.0;
+  -webkit-transition: opacity 1s;
+}
+
+.three-quarters-loader.updated {
+  opacity: 0;
+}


### PR DESCRIPTION
I am just starting on this so it is not yet finished. (A long list of features to add and I am new to open source )

![about](https://cloud.githubusercontent.com/assets/6040760/11213922/a2be36fc-8d79-11e5-9430-78323399f59c.gif)

This is a first step to merge the atom/release-notes and atom/about according to atom/atom#9164. This is currently only a mockup for how the about page can possibly evolve.

I will try to finish the rest as soon as possible, but I do hope to have some feedback on my current progress.

atom/release-notes#38 solved the problem of the squirrel, which I think should also be patched here. So I will have to wait for the PR to be merged too before I can update on the squirrel icon problem as mentioned in https://github.com/atom/atom/issues/6922. I will also probably merge the tests of the two packages.
