### PR TITLE
Link to the release notes.

### DIFF
--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -33,7 +33,8 @@ class AboutView extends ScrollView
             @span class: 'icon icon-clippy about-copy-version'
         @div class: 'about-actions', =>
           @div class: 'btn-group', =>
-            @button class: 'btn view-license', outlet: 'viewLicense', 'View License'
+            @button class: 'btn view-release-notes', outlet: 'viewReleaseNotes', 'Release Notes'
+            @button class: 'btn view-license', outlet: 'viewLicense', 'License'
             @button class: 'btn terms-of-use', outlet: 'viewTerms', 'Terms of Use'
         @p class: 'about-note about-metrics', =>
           @raw '''
@@ -69,6 +70,9 @@ class AboutView extends ScrollView
     @viewTerms.on 'click', ->
       # TODO: De-dupe this and use `application:open-terms-of-use`
       shell.openExternal 'https://help.github.com/articles/github-terms-of-service'
+
+    @viewReleaseNotes.on 'click', ->
+      shell.openExternal 'https://atom.io/releases'
 
     @on 'click', '.metrics-open', ->
       atom.workspace.open('atom://config/packages/metrics')


### PR DESCRIPTION
Also removed the "View" verb from "View License" since it was inconsistent and seemed superfluous.

![untitled](https://cloud.githubusercontent.com/assets/13760/12246027/07da1fee-b87a-11e5-9843-b87dbbf3c975.jpg)

/cc @atom/feedback 