### PR TITLE
Hide the Updates Container when the UpdateManager’s state is unknown

### DIFF
--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -167,6 +167,10 @@ class AboutView extends ScrollView
         @updateAvailableToInstall.addClass('is-shown')
       when UpdateManager.State.UpToDate
         @upToDate.addClass('is-shown')
+      else
+        @updatesContainer.hide()
+        console.warn("Unknown UpdateManager.State", {state: state})
+        atom.assert(false, "Unknown UpdateManager.State", {state: state})
 
   executeUpateActionForState: (state) ->
     switch state


### PR DESCRIPTION
This is a step towards understanding and fixing #17.

I couldn't reproduce the aforementioned issue locally, but after having a look at the code, it's possible that we're getting into an update state that we don't know how to handle. When this happens, the code added in this PR:

* Hides the Updates Container;
* Logs a warning into the console;
* Calls `atom.assert` so that an error gets reported into BugSnag too;

/cc: @atom/core 