### PR TITLE
Handle update errors

### DIFF
--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -62,7 +62,7 @@ class AboutView extends ScrollView
 
               @div class: 'about-updates-item app-update-error', outlet: 'updateError', =>
                 @span class: 'icon icon-x'
-                @span class: 'about-updates-label is-strong', 'There was an error checking/downloading updates.'
+                @span class: 'about-updates-label is-strong', outlet: 'updateErrorMessage'
 
             @button class: 'btn about-update-action-button', outlet: 'updateActionButton', 'Check for update'
 
@@ -172,6 +172,7 @@ class AboutView extends ScrollView
       when UpdateManager.State.UpToDate
         @upToDate.addClass('is-shown')
       when UpdateManager.State.Error
+        @updateErrorMessage.text(@updateManager.getErrorMessage())
         @updateError.addClass('is-shown')
 
   executeUpateActionForState: (state) ->

--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -60,6 +60,10 @@ class AboutView extends ScrollView
                 @span class: 'about-updates-version', outlet: 'updateAvailableVersion', '1.5.0'
                 @a class: 'about-updates-release-notes', outlet: 'viewUpdateReleaseNotes', 'Release Notes'
 
+              @div class: 'about-updates-item app-update-error', outlet: 'updateError', =>
+                @span class: 'icon icon-x'
+                @span class: 'about-updates-label is-strong', 'There was an error checking/downloading updates.'
+
             @button class: 'btn about-update-action-button', outlet: 'updateActionButton', 'Check for update'
 
           @div class: 'about-auto-updates', =>
@@ -167,10 +171,8 @@ class AboutView extends ScrollView
         @updateAvailableToInstall.addClass('is-shown')
       when UpdateManager.State.UpToDate
         @upToDate.addClass('is-shown')
-      else
-        @updatesContainer.hide()
-        console.warn("Unknown UpdateManager.State", {state: state})
-        atom.assert(false, "Unknown UpdateManager.State", {state: state})
+      when UpdateManager.State.Error
+        @updateError.addClass('is-shown')
 
   executeUpateActionForState: (state) ->
     switch state

--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -62,7 +62,7 @@ class AboutView extends ScrollView
 
               @div class: 'about-updates-item app-update-error', outlet: 'updateError', =>
                 @span class: 'icon icon-x'
-                @span class: 'about-updates-label is-strong', outlet: 'updateErrorMessage'
+                @span class: 'about-updates-label app-error-message is-strong', outlet: 'updateErrorMessage'
 
             @button class: 'btn about-update-action-button', outlet: 'updateActionButton', 'Check for update'
 

--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -167,6 +167,10 @@ class AboutView extends ScrollView
         @updateAvailableToInstall.addClass('is-shown')
       when UpdateManager.State.UpToDate
         @upToDate.addClass('is-shown')
+      else
+        @updatesContainer.hide()
+        console.warn("Unknown UpdateManager.State", {state: state})
+        atom.assert(false, "Unknown UpdateManager.State", {state: state})
 
   executeUpateActionForState: (state) ->
     switch state

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -80,6 +80,10 @@ export default class UpdateManager {
     return atom.config.set('core.automaticallyUpdate', enabled)
   }
 
+  getErrorMessage () {
+    return atom.autoUpdater.getErrorMessage()
+  }
+
   getState () {
     return this.state
   }

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -45,6 +45,9 @@ export default class UpdateManager {
       atom.autoUpdater.onUpdateNotAvailable(() => {
         this.setState(UpToDate)
       }),
+      atom.autoUpdater.onUpdateError(() => {
+        this.setState(ErrorState)
+      }),
       atom.config.observe('core.automaticallyUpdate', (value) => {
         this.autoUpdatesEnabled = value
         this.emitDidChange()

--- a/spec/about-spec.coffee
+++ b/spec/about-spec.coffee
@@ -92,8 +92,10 @@ describe "About", ->
         expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
         expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
 
+        spyOn(atom.autoUpdater, 'getErrorMessage').andReturn('an error message')
         MockUpdater.updateError()
         expect(aboutElement.querySelector('.app-update-error')).toBeVisible()
+        expect(aboutElement.querySelector('.app-error-message').textContent).toBe 'an error message'
         expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
         expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe false
         expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe 'Check now'

--- a/spec/about-spec.coffee
+++ b/spec/about-spec.coffee
@@ -85,6 +85,19 @@ describe "About", ->
         expect(aboutElement.querySelector('.app-up-to-date')).toBeVisible()
         expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
 
+      it "shows the correct panels when the app checks for updates and there is no update available", ->
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+
+        MockUpdater.checkForUpdate()
+        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
+
+        MockUpdater.updateError()
+        expect(aboutElement.querySelector('.app-update-error')).toBeVisible()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe false
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe 'Check now'
+
       it "shows the correct panels and button states when the app checks for updates and an update is downloaded", ->
         expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
         expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe false
@@ -284,6 +297,9 @@ triggerUpdate = (releaseVersion) ->
   atom.updateAvailable({releaseVersion})
 
 MockUpdater =
+  updateError: ->
+    atom.autoUpdater.emitter.emit('update-error')
+
   checkForUpdate: ->
     atom.autoUpdater.emitter.emit('did-begin-checking-for-update')
 


### PR DESCRIPTION
Supersedes and closes #19.
Fixes #17.
Depends on https://github.com/atom/atom/pull/11314.

This PR introduces some UI for the auto-update error state:

![screen shot 2016-03-31 at 10 12 53](https://cloud.githubusercontent.com/assets/482957/14169735/dc36739e-f729-11e5-8b85-277f3427a09b.png)

@simurai @thedaniel: I'd :heart: to have your feedback on this, since you worked on #12.

/cc: @atom/core 