### PR TITLE
Copy change

### DIFF
--- a/lib/about-status-bar.js
+++ b/lib/about-status-bar.js
@@ -17,7 +17,7 @@ export default class AboutStatusBar extends View {
       atom.workspace.open('atom://about')
     })
 
-    this.subscriptions.add(atom.tooltips.add(this.element, {title: 'An update will be installed the next time Atom is relaunched.<br/><br/>Click to view release notes.'}))
+    this.subscriptions.add(atom.tooltips.add(this.element, {title: 'An update will be installed the next time Atom is relaunched.<br/><br/>Click for more information.'}))
   }
 
   detached () {


### PR DESCRIPTION
Copy change to better reflect what the squirrel button does. Just a small annoyance of mine since the new behavior of the release notes/upgrade path isn't to jump to the release notes but to go to the "about" page where you can click *another* button to get to the release notes.

Maybe there's better copy still, but I figured I could at least get the ball rolling!