### PR TITLE
Fix specs on stable

### DIFF
--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -6,7 +6,7 @@ const Unsupported = 'unsupported'
 const Idle = 'idle'
 const CheckingForUpdate = 'checking'
 const DownloadingUpdate = 'downloading'
-const UpdateAvailableToInstall = 'update-avialable'
+const UpdateAvailableToInstall = 'update-available'
 const UpToDate = 'no-update-available'
 const ErrorState = 'error'
 
@@ -19,9 +19,9 @@ export default class UpdateManager {
     this.listenForAtomEvents()
   }
 
-  // TODO: Remove this when stable has atom.autoUpdater
+  // TODO: Remove this when stable has atom.autoUpdater.onUpdateError
   currentAtomHasAutoUpdateFunctionality () {
-    return !!atom.autoUpdater
+    return !!atom.autoUpdater.onUpdateError
   }
 
   listenForAtomEvents () {

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -43,11 +43,12 @@ export default class UpdateManager {
     )
 
     // TODO: Combine this with the subscriptions above once stable has onUpdateError
-    if(!!atom.autoUpdater.onUpdateError) {
+    if (atom.autoUpdater.onUpdateError) {
       this.subscriptions.add(
         atom.autoUpdater.onUpdateError(() => {
-        this.setState(ErrorState)
-      }))
+          this.setState(ErrorState)
+        })
+      )
     }
 
     // TODO: When https://github.com/atom/electron/issues/4587 is closed we can add this support.

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -19,17 +19,8 @@ export default class UpdateManager {
     this.listenForAtomEvents()
   }
 
-  // TODO: Remove this when stable has atom.autoUpdater.onUpdateError
-  currentAtomHasAutoUpdateFunctionality () {
-    return !!atom.autoUpdater.onUpdateError
-  }
-
   listenForAtomEvents () {
     this.subscriptions = new CompositeDisposable()
-
-    if (!this.currentAtomHasAutoUpdateFunctionality()) {
-      return
-    }
 
     this.subscriptions.add(
       atom.autoUpdater.onDidBeginCheckingForUpdate(() => {
@@ -45,14 +36,19 @@ export default class UpdateManager {
       atom.autoUpdater.onUpdateNotAvailable(() => {
         this.setState(UpToDate)
       }),
-      atom.autoUpdater.onUpdateError(() => {
-        this.setState(ErrorState)
-      }),
       atom.config.observe('core.automaticallyUpdate', (value) => {
         this.autoUpdatesEnabled = value
         this.emitDidChange()
       })
     )
+
+    // TODO: Combine this with the subscriptions above once stable has onUpdateError
+    if(!!atom.autoUpdater.onUpdateError) {
+      this.subscriptions.add(
+        atom.autoUpdater.onUpdateError(() => {
+        this.setState(ErrorState)
+      }))
+    }
 
     // TODO: When https://github.com/atom/electron/issues/4587 is closed we can add this support.
     // atom.autoUpdater.onUpdateAvailable =>
@@ -94,11 +90,7 @@ export default class UpdateManager {
   }
 
   resetState () {
-    if (this.currentAtomHasAutoUpdateFunctionality()) {
-      this.state = atom.autoUpdater.platformSupportsUpdates() ? atom.autoUpdater.getState() : Unsupported
-    } else {
-      this.state = Unsupported
-    }
+    this.state = atom.autoUpdater.platformSupportsUpdates() ? atom.autoUpdater.getState() : Unsupported
     this.emitDidChange()
   }
 

--- a/spec/about-spec.coffee
+++ b/spec/about-spec.coffee
@@ -44,7 +44,7 @@ describe "About", ->
         expect(atom.clipboard.read()).toBe atom.getVersion()
 
   # TODO: remove when this function is in beta / stable
-  return unless atom.autoUpdater?.getState?
+  return unless atom.autoUpdater?.onUpdateError?
 
   describe "updates", ->
     [aboutElement, updateManager] = []

--- a/spec/about-spec.coffee
+++ b/spec/about-spec.coffee
@@ -43,9 +43,6 @@ describe "About", ->
         $(versionContainer).click()
         expect(atom.clipboard.read()).toBe atom.getVersion()
 
-  # TODO: remove when this function is in beta / stable
-  return unless atom.autoUpdater?.onUpdateError?
-
   describe "updates", ->
     [aboutElement, updateManager] = []
 
@@ -86,6 +83,9 @@ describe "About", ->
         expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
 
       it "shows the correct panels when the app checks for updates and there is no update available", ->
+        # TODO: remove when this function is in beta / stable
+        return unless atom.autoUpdater?.onUpdateError?
+
         expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
 
         MockUpdater.checkForUpdate()


### PR DESCRIPTION
Atom 1.7.1 contains `atom.autoUpdater`, but the update manager references `atom.autoUpdater.onUpdateError()`, which was only added in Atom 1.8.0.

This may fix a potential bug in the About package that's shipped with Atom 1.7.1, but I'm not too sure.

In addition I've fixed a typo regarding `update-available`.

/cc @as-cii