### PR TITLE
One-liner: gave the status-bar squirrel icon cursor:pointer

### DIFF
--- a/styles/about.less
+++ b/styles/about.less
@@ -168,5 +168,6 @@
 // the blue squirrel --------------------------------
 
 .about-release-notes {
+  cursor: pointer;
   color: @background-color-info;
 }

--- a/styles/about.less
+++ b/styles/about.less
@@ -168,6 +168,8 @@
 // the blue squirrel --------------------------------
 
 .about-release-notes {
-  cursor: pointer;
   color: @background-color-info;
+  &:hover {
+    color: lighten(@background-color-info, 15%);
+  }
 }


### PR DESCRIPTION
The squirrel icon in the status bar should probably use the pointer cursor on hover since it is clickable and opens a new tab. The tooltip is the only indication that the icon is a link, I think this is a slight improvement.