### PR TITLE
Convert all specs to use async/await to address flakiness

### DIFF
--- a/spec/about-spec.js
+++ b/spec/about-spec.js
@@ -1,14 +1,13 @@
 /** @babel */
 
+import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers'
+
 describe('About', () => {
   let workspaceElement
 
-  beforeEach(() => {
+  beforeEach(async () => {
     workspaceElement = atom.views.getView(atom.workspace)
-
-    waitsForPromise(() => {
-      return atom.packages.activatePackage('about')
-    })
+    await atom.packages.activatePackage('about')
   })
 
   it('deserializes correctly', () => {
@@ -21,7 +20,7 @@ describe('About', () => {
   })
 
   describe('when the about:about-atom command is triggered', () => {
-    it('shows the About Atom view', () => {
+    it('shows the About Atom view', async () => {
       // Attaching the workspaceElement to the DOM is required to allow the
       // `toBeVisible()` matchers to work. Anything testing visibility or focus
       // requires that the workspaceElement is on the DOM. Tests that attach the
@@ -29,33 +28,21 @@ describe('About', () => {
       jasmine.attachToDOM(workspaceElement)
 
       expect(workspaceElement.querySelector('.about')).not.toExist()
-      atom.workspace.open('atom://about')
+      await atom.workspace.open('atom://about')
 
-      waitsFor(() => {
-        return atom.workspace.getActivePaneItem()
-      })
-
-      runs(() => {
-        let aboutElement = workspaceElement.querySelector('.about')
-        expect(aboutElement).toBeVisible()
-      })
+      let aboutElement = workspaceElement.querySelector('.about')
+      expect(aboutElement).toBeVisible()
     })
   })
 
   describe('when the version number is clicked', () => {
-    it('copies the version number to the clipboard', () => {
-      atom.workspace.open('atom://about')
+    it('copies the version number to the clipboard', async () => {
+      await atom.workspace.open('atom://about')
 
-      waitsFor(() => {
-        return atom.workspace.getActivePaneItem()
-      })
-
-      runs(() => {
-        let aboutElement = workspaceElement.querySelector('.about')
-        let versionContainer = aboutElement.querySelector('.about-version-container')
-        versionContainer.click()
-        expect(atom.clipboard.read()).toBe(atom.getVersion())
-      })
+      let aboutElement = workspaceElement.querySelector('.about')
+      let versionContainer = aboutElement.querySelector('.about-version-container')
+      versionContainer.click()
+      expect(atom.clipboard.read()).toBe(atom.getVersion())
     })
   })
 })

--- a/spec/about-spec.js
+++ b/spec/about-spec.js
@@ -1,6 +1,6 @@
 /** @babel */
 
-import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers'
+import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
 
 describe('About', () => {
   let workspaceElement

--- a/spec/about-status-bar-spec.js
+++ b/spec/about-status-bar-spec.js
@@ -1,6 +1,6 @@
 /** @babel */
 
-import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './helpers/async-spec-helpers'
+import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
 import MockUpdater from './mocks/updater'
 
 describe('the status bar', () => {

--- a/spec/about-status-bar-spec.js
+++ b/spec/about-status-bar-spec.js
@@ -1,11 +1,12 @@
 /** @babel */
 
+import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './helpers/async-spec-helpers'
 import MockUpdater from './mocks/updater'
 
 describe('the status bar', () => {
-  let workspaceElement = null
+  let workspaceElement
 
-  beforeEach(() => {
+  beforeEach(async () => {
     let storage = {}
 
     spyOn(window.localStorage, 'setItem').andCallFake((key, value) => {
@@ -19,17 +20,9 @@ describe('the status bar', () => {
 
     workspaceElement = atom.views.getView(atom.workspace)
 
-    waitsForPromise(() => {
-      return atom.packages.activatePackage('status-bar')
-    })
-
-    waitsForPromise(() => {
-      return atom.packages.activatePackage('about')
-    })
-
-    waitsForPromise(() => {
-      return atom.workspace.open('sample.js')
-    })
+    await atom.packages.activatePackage('status-bar')
+    await atom.packages.activatePackage('about')
+    await atom.workspace.open('sample.js')
   })
 
   afterEach(() => {
@@ -50,53 +43,33 @@ describe('the status bar', () => {
     })
 
     describe('clicking on the status', () => {
-      it('opens the about page', () => {
+      it('opens the about page', async () => {
         MockUpdater.triggerUpdate('42')
         workspaceElement.querySelector('.about-release-notes').click()
-
-        waitsFor(() => {
-          return workspaceElement.querySelector('.about')
-        })
-
-        runs(() => {
-          expect(workspaceElement.querySelector('.about')).toExist()
-        })
+        await conditionPromise(() => workspaceElement.querySelector('.about'))
+        expect(workspaceElement.querySelector('.about')).toExist()
       })
     })
 
-    it('continues to show the squirrel until Atom is updated to the new version', () => {
+    it('continues to show the squirrel until Atom is updated to the new version', async () => {
       MockUpdater.triggerUpdate('42')
       expect(workspaceElement).toContain('.about-release-notes')
 
-      runs(() => {
-        atom.packages.deactivatePackage('about')
-        expect(workspaceElement).not.toContain('.about-release-notes')
-      })
+      atom.packages.deactivatePackage('about')
+      expect(workspaceElement).not.toContain('.about-release-notes')
 
-      waitsForPromise(() => {
-        return atom.packages.activatePackage('about')
-      })
-      waits(1) // Service consumption hooks are deferred until the next tick
-      runs(() => {
-        expect(workspaceElement).toContain('.about-release-notes')
-      })
+      await atom.packages.activatePackage('about')
+      await Promise.resolve() // Service consumption hooks are deferred until the next tick
+      expect(workspaceElement).toContain('.about-release-notes')
 
-      runs(() => {
-        atom.packages.deactivatePackage('about')
-        expect(workspaceElement).not.toContain('.about-release-notes')
-      })
+      atom.packages.deactivatePackage('about')
+      expect(workspaceElement).not.toContain('.about-release-notes')
 
-      runs(() => {
-        spyOn(atom, 'getVersion').andReturn('42')
-      })
+      spyOn(atom, 'getVersion').andReturn('42')
+      await atom.packages.activatePackage('about')
 
-      waitsForPromise(() => {
-        return atom.packages.activatePackage('about')
-      })
-      waits(1) // Service consumption hooks are deferred until the next tick
-      runs(() => {
-        expect(workspaceElement).not.toContain('.about-release-notes')
-      })
+      await Promise.resolve() // Service consumption hooks are deferred until the next tick
+      expect(workspaceElement).not.toContain('.about-release-notes')
     })
   })
 })

--- a/spec/helpers/async-spec-helpers.js
+++ b/spec/helpers/async-spec-helpers.js
@@ -1,0 +1,65 @@
+/** @babel */
+
+const {now} = Date
+const {setTimeout} = global
+
+export function beforeEach (fn) {
+  global.beforeEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+export function afterEach (fn) {
+  global.afterEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+['it', 'fit', 'ffit', 'fffit'].forEach(function (name) {
+  module.exports[name] = function (description, fn) {
+    global[name](description, function () {
+      const result = fn()
+      if (result instanceof Promise) {
+        waitsForPromise(() => result)
+      }
+    })
+  }
+})
+
+export async function conditionPromise (condition)  {
+  const startTime = now()
+
+  while (true) {
+    await timeoutPromise(100)
+
+    if (await condition()) {
+      return
+    }
+
+    if (now() - startTime > 5000) {
+      throw new Error("Timed out waiting on condition")
+    }
+  }
+}
+
+export function timeoutPromise (timeout) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, timeout)
+  })
+}
+
+function waitsForPromise (fn) {
+  const promise = fn()
+  global.waitsFor('spec promise to resolve', function (done) {
+    promise.then(done, function (error) {
+      jasmine.getEnv().currentSpec.fail(error)
+      done()
+    })
+  })
+}

--- a/spec/helpers/async-spec-helpers.js
+++ b/spec/helpers/async-spec-helpers.js
@@ -32,7 +32,7 @@ export function afterEach (fn) {
   }
 })
 
-export async function conditionPromise (condition)  {
+export async function conditionPromise (condition) {
   const startTime = now()
 
   while (true) {
@@ -43,7 +43,7 @@ export async function conditionPromise (condition)  {
     }
 
     if (now() - startTime > 5000) {
-      throw new Error("Timed out waiting on condition")
+      throw new Error('Timed out waiting on condition')
     }
   }
 }

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -1,7 +1,7 @@
 /** @babel */
 
 import {shell} from 'electron'
-import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers'
+import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
 import About from '../lib/main'
 import AboutView from '../lib/components/about-view'
 import UpdateView from '../lib/components/update-view'

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -1,6 +1,7 @@
 /** @babel */
 
 import {shell} from 'electron'
+import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers'
 import About from '../lib/main'
 import AboutView from '../lib/components/about-view'
 import UpdateView from '../lib/components/update-view'
@@ -12,194 +13,114 @@ describe('updates', () => {
   let workspaceElement
   let scheduler
 
-  beforeEach(() => {
+  beforeEach(async () => {
     workspaceElement = atom.views.getView(atom.workspace)
+    await atom.packages.activatePackage('about')
+    spyOn(atom.autoUpdater, 'getState').andReturn('idle')
+    spyOn(atom.autoUpdater, 'checkForUpdate')
+    spyOn(atom.autoUpdater, 'platformSupportsUpdates').andReturn(true)
 
-    waitsForPromise(() => {
-      return atom.packages.activatePackage('about')
-    })
-    runs(() => {
-      spyOn(atom.autoUpdater, 'getState').andReturn('idle')
-      spyOn(atom.autoUpdater, 'checkForUpdate')
-      spyOn(atom.autoUpdater, 'platformSupportsUpdates').andReturn(true)
-      jasmine.attachToDOM(workspaceElement)
-      atom.workspace.open('atom://about')
-    })
-    waitsFor(() => {
-      return atom.workspace.getActivePaneItem()
-    })
-    runs(() => {
-      aboutElement = workspaceElement.querySelector('.about')
-      updateManager = About.model.state.updateManager
-      scheduler = AboutView.getScheduler()
-    })
+    jasmine.attachToDOM(workspaceElement)
+    await atom.workspace.open('atom://about')
+    aboutElement = workspaceElement.querySelector('.about')
+    updateManager = About.model.state.updateManager
+    scheduler = AboutView.getScheduler()
   })
 
   describe('when the updates are not supported by the platform', () => {
-    it('hides the auto update UI', () => {
+    it('hides the auto update UI', async () => {
       atom.autoUpdater.platformSupportsUpdates.andReturn(false)
       updateManager.resetState()
-
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.about-updates')).not.toBeVisible()
-      })
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.about-updates')).not.toBeVisible()
     })
   })
 
   describe('when updates are supported by the platform', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       atom.autoUpdater.platformSupportsUpdates.andReturn(true)
       updateManager.resetState()
+      await scheduler.getNextUpdatePromise()
     })
 
     it('shows the auto update UI', () => {
       expect(aboutElement.querySelector('.about-updates')).toBeVisible()
     })
 
-    it('shows the correct panels when the app checks for updates and there is no update available', () => {
+    it('shows the correct panels when the app checks for updates and there is no update available', async () => {
       expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
 
-      runs(() => {
-        MockUpdater.checkForUpdate()
-      })
+      MockUpdater.checkForUpdate()
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+      expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
 
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
-        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
-
-        MockUpdater.updateNotAvailable()
-      })
-
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-up-to-date')).toBeVisible()
-        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-      })
+      MockUpdater.updateNotAvailable()
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-up-to-date')).toBeVisible()
+      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
     })
 
-    it('shows the correct panels when the app checks for updates and encounters an error', () => {
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
+    it('shows the correct panels when the app checks for updates and encounters an error', async () => {
+      expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
 
-      runs(() => {
-        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-      })
+      MockUpdater.checkForUpdate()
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+      expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
 
-      runs(() => {
-        MockUpdater.checkForUpdate()
-      })
-
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
-        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
-      })
-
-      runs(() => {
-        spyOn(atom.autoUpdater, 'getErrorMessage').andReturn('an error message')
-        MockUpdater.updateError()
-      })
-
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-update-error')).toBeVisible()
-        expect(aboutElement.querySelector('.app-error-message').textContent).toBe('an error message')
-        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
-        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-      })
+      spyOn(atom.autoUpdater, 'getErrorMessage').andReturn('an error message')
+      MockUpdater.updateError()
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-update-error')).toBeVisible()
+      expect(aboutElement.querySelector('.app-error-message').textContent).toBe('an error message')
+      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
+      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
     })
 
-    it('shows the correct panels and button states when the app checks for updates and an update is downloaded', () => {
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
+    it('shows the correct panels and button states when the app checks for updates and an update is downloaded', async () => {
+      expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
+      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
 
-      runs(() => {
-        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
-        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-      })
+      MockUpdater.checkForUpdate()
+      await scheduler.getNextUpdatePromise()
 
-      runs(() => {
-        MockUpdater.checkForUpdate()
-      })
+      expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+      expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
+      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
+      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
 
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
+      MockUpdater.downloadUpdate()
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+      expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
+      // TODO: at some point it would be nice to be able to cancel an update download, and then this would be a cancel button
+      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
+      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
 
-      runs(() => {
-        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
-        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
-        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
-        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
+      MockUpdater.finishDownloadingUpdate(42)
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-downloading-update')).not.toBeVisible()
+      expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
 
-        MockUpdater.downloadUpdate()
-      })
-
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-        expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
-        // TODO: at some point it would be nice to be able to cancel an update download, and then this would be a cancel button
-        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
-        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-
-        MockUpdater.finishDownloadingUpdate(42)
-      })
-
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-downloading-update')).not.toBeVisible()
-        expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
-
-        expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42')
-        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
-        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Restart and install')
-      })
+      expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42')
+      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
+      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Restart and install')
     })
 
-    it('opens the release notes for the downloaded release when the release notes link are clicked', () => {
+    it('opens the release notes for the downloaded release when the release notes link are clicked', async () => {
       MockUpdater.finishDownloadingUpdate('1.2.3')
+      await scheduler.getNextUpdatePromise()
 
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
+      spyOn(shell, 'openExternal')
+      let link = aboutElement.querySelector('.app-update-available-to-install .about-updates-release-notes')
+      link.click()
 
-      runs(() => {
-        spyOn(shell, 'openExternal')
-        let link = aboutElement.querySelector('.app-update-available-to-install .about-updates-release-notes')
-        link.click()
-
-        let args = shell.openExternal.mostRecentCall.args
-        expect(shell.openExternal).toHaveBeenCalled()
-        expect(args[0]).toContain('/v1.2.3')
-      })
+      let args = shell.openExternal.mostRecentCall.args
+      expect(shell.openExternal).toHaveBeenCalled()
+      expect(args[0]).toContain('/v1.2.3')
     })
 
     it('executes checkForUpdate() when the check for update button is clicked', () => {
@@ -208,93 +129,64 @@ describe('updates', () => {
       expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled()
     })
 
-    it('executes restartAndInstallUpdate() when the restart and install button is clicked', () => {
+    it('executes restartAndInstallUpdate() when the restart and install button is clicked', async () => {
       spyOn(atom.autoUpdater, 'restartAndInstallUpdate')
       MockUpdater.finishDownloadingUpdate(42)
+      await scheduler.getNextUpdatePromise()
 
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        let button = aboutElement.querySelector('.about-update-action-button')
-        button.click()
-        expect(atom.autoUpdater.restartAndInstallUpdate).toHaveBeenCalled()
-      })
+      let button = aboutElement.querySelector('.about-update-action-button')
+      button.click()
+      expect(atom.autoUpdater.restartAndInstallUpdate).toHaveBeenCalled()
     })
 
-    it("starts in the same state as atom's AutoUpdateManager", () => {
+    it("starts in the same state as atom's AutoUpdateManager", async () => {
       atom.autoUpdater.getState.andReturn('downloading')
       updateManager.resetState()
 
-      waitsForPromise(() => {
-        return scheduler.getNextUpdatePromise()
-      })
-
-      runs(() => {
-        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-        expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
-        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
-        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-      })
+      await scheduler.getNextUpdatePromise()
+      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+      expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
+      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
+      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
     })
 
     describe('when core.automaticallyUpdate is toggled', () => {
-      beforeEach(() => {
-        atom.config.set('core.automaticallyUpdate', true)
+      beforeEach(async () => {
+        expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
         atom.autoUpdater.checkForUpdate.reset()
-
-        waitsForPromise(() => {
-          return scheduler.getNextUpdatePromise()
-        })
       })
 
-      it('shows the auto update UI', () => {
+      it('shows the auto update UI', async () => {
         expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
         expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
         expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
 
         atom.config.set('core.automaticallyUpdate', false)
+        await scheduler.getNextUpdatePromise()
 
-        waitsForPromise(() => {
-          return scheduler.getNextUpdatePromise()
-        })
-
-        runs(() => {
-          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
-          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
-        })
+        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
       })
 
-      it('updates config and the UI when the checkbox is used to toggle', () => {
+      it('updates config and the UI when the checkbox is used to toggle', async () => {
         expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
 
         aboutElement.querySelector('.about-auto-updates input').click()
+        await scheduler.getNextUpdatePromise()
 
-        waitsForPromise(() => {
-          return scheduler.getNextUpdatePromise()
-        })
+        expect(atom.config.get('core.automaticallyUpdate')).toBe(false)
+        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
 
-        runs(() => {
-          expect(atom.config.get('core.automaticallyUpdate')).toBe(false)
-          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
-          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
+        aboutElement.querySelector('.about-auto-updates input').click()
+        await scheduler.getNextUpdatePromise()
 
-          aboutElement.querySelector('.about-auto-updates input').click()
-        })
-
-        waitsForPromise(() => {
-          return scheduler.getNextUpdatePromise()
-        })
-
-        runs(() => {
-          expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
-          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
-          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
-        })
+        expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
+        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
       })
 
       describe('checking for updates', function () {


### PR DESCRIPTION
Jasmine `waitsFor` and `runs` constructs push functions onto an async queue, creating unreliability when combined with `scheduler.getNextUpdatePromise` because we're asking for the promise asynchronously after an arbitrary gap in time. The promise is for the *next* update, so if the update has already happened by the time we request it we block forever.

Using `async`/`await` makes the tests more readable and also makes it easier to ensure that we request the next scheduler update promise *synchronously* after taking an action that causes an update. I hope this makes the tests less flaky. I think it will.

/cc @mnquintana @damieng 