### PR TITLE
Compile and test against stable & beta, x64 & x86

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
-version: "{build}"
-
-platform: x64
+platform:
+  - x64
+  - x86
 
 branches:
     only:
@@ -18,7 +18,7 @@ environment:
   - ATOM_CHANNEL: beta
 
 install:
-  - ps: Install-Product node 4
+  - ps: Install-Product node 6
 
 build_script:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))


### PR DESCRIPTION
### Description of the Change

Using nodejs 6 instead of nodejs 4! Appveyor test against stable and beta, x64 and x86.