### PR TITLE
Always listen to onDidCompleteDownloadingUpdate

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,12 +24,10 @@ export default {
       window.localStorage.removeItem(AvailableUpdateVersion)
     }
 
-    if (atom.isReleasedVersion()) {
-      this.subscriptions.add(atom.onUpdateAvailable(({releaseVersion}) => {
-        window.localStorage.setItem(AvailableUpdateVersion, releaseVersion)
-        this.showStatusBarIfNeeded()
-      }))
-    }
+    this.subscriptions.add(atom.autoUpdater.onDidCompleteDownloadingUpdate(({releaseVersion}) => {
+      window.localStorage.setItem(AvailableUpdateVersion, releaseVersion)
+      this.showStatusBarIfNeeded()
+    }))
   },
 
   deactivate () {

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -35,20 +35,14 @@ export default class UpdateManager {
       atom.autoUpdater.onUpdateNotAvailable(() => {
         this.setState(UpToDate)
       }),
+      atom.autoUpdater.onUpdateError(() => {
+        this.setState(ErrorState)
+      }),
       atom.config.observe('core.automaticallyUpdate', (value) => {
         this.autoUpdatesEnabled = value
         this.emitDidChange()
       })
     )
-
-    // TODO: Combine this with the subscriptions above once stable has onUpdateError
-    if (atom.autoUpdater.onUpdateError) {
-      this.subscriptions.add(
-        atom.autoUpdater.onUpdateError(() => {
-          this.setState(ErrorState)
-        })
-      )
-    }
 
     // TODO: When https://github.com/atom/electron/issues/4587 is closed we can add this support.
     // atom.autoUpdater.onUpdateAvailable =>

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -29,8 +29,7 @@ export default class UpdateManager {
       atom.autoUpdater.onDidBeginDownloadingUpdate(() => {
         this.setState(DownloadingUpdate)
       }),
-      atom.autoUpdater.onDidCompleteDownloadingUpdate((detail) => {
-        let {releaseVersion} = detail
+      atom.autoUpdater.onDidCompleteDownloadingUpdate(({releaseVersion}) => {
         this.setAvailableVersion(releaseVersion)
       }),
       atom.autoUpdater.onUpdateNotAvailable(() => {

--- a/spec/about-status-bar-spec.js
+++ b/spec/about-status-bar-spec.js
@@ -16,8 +16,6 @@ describe('the status bar', () => {
       return storage[key]
     })
 
-    spyOn(atom, 'isReleasedVersion').andReturn(true)
-
     workspaceElement = atom.views.getView(atom.workspace)
 
     await atom.packages.activatePackage('status-bar')
@@ -38,13 +36,13 @@ describe('the status bar', () => {
 
   describe('with an update', () => {
     it('shows the view when the update is made available', () => {
-      MockUpdater.triggerUpdate('42')
+      MockUpdater.finishDownloadingUpdate('42')
       expect(workspaceElement).toContain('.about-release-notes')
     })
 
     describe('clicking on the status', () => {
       it('opens the about page', async () => {
-        MockUpdater.triggerUpdate('42')
+        MockUpdater.finishDownloadingUpdate('42')
         workspaceElement.querySelector('.about-release-notes').click()
         await conditionPromise(() => workspaceElement.querySelector('.about'))
         expect(workspaceElement.querySelector('.about')).toExist()
@@ -52,7 +50,7 @@ describe('the status bar', () => {
     })
 
     it('continues to show the squirrel until Atom is updated to the new version', async () => {
-      MockUpdater.triggerUpdate('42')
+      MockUpdater.finishDownloadingUpdate('42')
       expect(workspaceElement).toContain('.about-release-notes')
 
       atom.packages.deactivatePackage('about')

--- a/spec/about-status-bar-spec.js
+++ b/spec/about-status-bar-spec.js
@@ -35,7 +35,7 @@ describe('the status bar', () => {
   })
 
   describe('with an update', () => {
-    it('shows the view when the update is made available', () => {
+    it('shows the view when the update finishes downloading', () => {
       MockUpdater.finishDownloadingUpdate('42')
       expect(workspaceElement).toContain('.about-release-notes')
     })

--- a/spec/mocks/updater.js
+++ b/spec/mocks/updater.js
@@ -18,12 +18,6 @@ export default {
   },
 
   finishDownloadingUpdate (releaseVersion) {
-    let version = {releaseVersion}
-    atom.autoUpdater.emitter.emit('did-complete-downloading-update', version)
-    atom.updateAvailable(version)
-  },
-
-  triggerUpdate (releaseVersion) {
-    atom.updateAvailable({releaseVersion})
+    atom.autoUpdater.emitter.emit('did-complete-downloading-update', {releaseVersion})
   }
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

@petewalker noted in #44 that different parts of About listen to different update events.  `atom.onUpdateAvailable` seems to fire when an update starts downloading, and is what is currently used in `main.js`.  `atom.autoUpdater.onDidCompleteDownloadingUpdate` is fired when an update finishes downloading, and is what is currently used in `update-manager.js`.
Since the tooltip infers that the update has already been downloaded and is waiting to install, I replaced `onUpdateAvailable` with `onDidcompleteDownloadingUpdate` (and also because there's a todo in the Atom codebase about moving away from `onUpdateAvailable`).
In addition, I removed a check to make sure Atom is running a released version before checking for the download completion, because theoretically if Atom isn't running on a released version then it will never receive a download completion event.  This allowed some cleanup of the specs.

### Alternate Designs

I could have went with onUpdateAvailable instead of the other way around, but see above for why I didn't.

### Benefits

Some minor code deduplication.

### Possible Drawbacks

None that I can foresee.

### Applicable Issues
None

/cc @mnquintana