### PR TITLE
Use a single UpdateManager

### DIFF
--- a/lib/about.js
+++ b/lib/about.js
@@ -5,7 +5,6 @@ import {CompositeDisposable, Emitter} from 'atom'
 // Deferred requires
 let shell
 let AboutView
-let UpdateManager
 
 export default class About {
   constructor (initialState) {
@@ -25,7 +24,7 @@ export default class About {
 
     this.subscriptions.add(atom.commands.add('atom-workspace', 'about:view-release-notes', () => {
       shell = shell || require('electron').shell
-      shell.openExternal(this.getUpdateManager().getReleaseNotesURLForCurrentVersion())
+      shell.openExternal(this.state.updateManager.getReleaseNotesURLForCurrentVersion())
     }))
   }
 
@@ -56,18 +55,6 @@ export default class About {
     this.emitter.on('did-change', callback)
   }
 
-  getUpdateManager () {
-    UpdateManager = UpdateManager || require('./update-manager')
-
-    if (!this.state.updateManager) {
-      this.setState({
-        updateManager: new UpdateManager()
-      })
-    }
-
-    return this.state.updateManager
-  }
-
   deserialize (state) {
     if (!this.views.aboutView) {
       AboutView = AboutView || require('./components/about-view')
@@ -76,7 +63,7 @@ export default class About {
 
       this.views.aboutView = new AboutView({
         uri: this.state.uri,
-        updateManager: this.getUpdateManager(),
+        updateManager: this.state.updateManager,
         currentVersion: this.state.currentVersion,
         availableVersion: this.state.updateManager.getAvailableVersion()
       })

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,15 +15,7 @@ export default {
   activate () {
     this.subscriptions = new CompositeDisposable()
 
-    UpdateManager = UpdateManager || require('./update-manager')
-    updateManager = updateManager || new UpdateManager()
-
-    About = About || require('./about')
-    this.model = new About({
-      uri: AboutURI,
-      currentVersion: atom.getVersion(),
-      updateManager: updateManager
-    })
+    this.createModel()
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
     if (availableVersion === atom.getVersion()) {
@@ -56,18 +48,22 @@ export default {
 
   deserializeAboutView (state) {
     if (!this.model) {
-      UpdateManager = UpdateManager || require('./update-manager')
-      updateManager = updateManager || new UpdateManager()
-
-      About = About || require('./about')
-      this.model = new About({
-        uri: AboutURI,
-        currentVersion: atom.getVersion(),
-        updateManager: updateManager
-      })
+      this.createModel()
     }
 
     return this.model.deserialize(state)
+  },
+
+  createModel () {
+    UpdateManager = UpdateManager || require('./update-manager')
+    updateManager = updateManager || new UpdateManager()
+
+    About = About || require('./about')
+    this.model = new About({
+      uri: AboutURI,
+      currentVersion: atom.getVersion(),
+      updateManager: updateManager
+    })
   },
 
   isUpdateAvailable () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,8 @@ import {CompositeDisposable} from 'atom'
 
 let About
 let StatusBarView
+let UpdateManager
+let updateManager
 
 // The local storage key for the available update version.
 const AvailableUpdateVersion = 'about:version-available'
@@ -13,10 +15,14 @@ export default {
   activate () {
     this.subscriptions = new CompositeDisposable()
 
+    UpdateManager = UpdateManager || require('./update-manager')
+    updateManager = updateManager || new UpdateManager()
+
     About = About || require('./about')
     this.model = new About({
       uri: AboutURI,
-      currentVersion: atom.getVersion()
+      currentVersion: atom.getVersion(),
+      updateManager: updateManager
     })
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
@@ -24,15 +30,23 @@ export default {
       window.localStorage.removeItem(AvailableUpdateVersion)
     }
 
-    this.subscriptions.add(atom.autoUpdater.onDidCompleteDownloadingUpdate(({releaseVersion}) => {
-      window.localStorage.setItem(AvailableUpdateVersion, releaseVersion)
-      this.showStatusBarIfNeeded()
+    this.subscriptions.add(updateManager.onDidChange(() => {
+      if (updateManager.getState() === UpdateManager.State.UpdateAvailableToInstall) {
+        window.localStorage.setItem(AvailableUpdateVersion, updateManager.getAvailableVersion())
+        this.showStatusBarIfNeeded()
+      }
     }))
   },
 
   deactivate () {
     this.model.destroy()
     if (this.statusBarTile) this.statusBarTile.destroy()
+
+    if (updateManager) {
+      updateManager.dispose()
+      UpdateManager = undefined
+      updateManager = undefined
+    }
   },
 
   consumeStatusBar (statusBar) {
@@ -42,10 +56,14 @@ export default {
 
   deserializeAboutView (state) {
     if (!this.model) {
+      UpdateManager = UpdateManager || require('./update-manager')
+      updateManager = updateManager || new UpdateManager()
+
       About = About || require('./about')
       this.model = new About({
         uri: AboutURI,
-        currentVersion: atom.getVersion()
+        currentVersion: atom.getVersion(),
+        updateManager: updateManager
       })
     }
 

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -2,7 +2,7 @@
 
 import {shell} from 'electron'
 import {it, fit, ffit, fffit, beforeEach, afterEach} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
-import About from '../lib/main'
+import main from '../lib/main'
 import AboutView from '../lib/components/about-view'
 import UpdateView from '../lib/components/update-view'
 import MockUpdater from './mocks/updater'
@@ -32,7 +32,7 @@ describe('updates', () => {
     jasmine.attachToDOM(workspaceElement)
     await atom.workspace.open('atom://about')
     aboutElement = workspaceElement.querySelector('.about')
-    updateManager = About.model.state.updateManager
+    updateManager = main.model.state.updateManager
     scheduler = AboutView.getScheduler()
   })
 

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -7,7 +7,7 @@ import AboutView from '../lib/components/about-view'
 import UpdateView from '../lib/components/update-view'
 import MockUpdater from './mocks/updater'
 
-describe('updates', () => {
+describe('UpdateView', () => {
   let aboutElement
   let updateManager
   let workspaceElement
@@ -28,220 +28,241 @@ describe('updates', () => {
     spyOn(atom.autoUpdater, 'getState').andReturn('idle')
     spyOn(atom.autoUpdater, 'checkForUpdate')
     spyOn(atom.autoUpdater, 'platformSupportsUpdates').andReturn(true)
-
-    jasmine.attachToDOM(workspaceElement)
-    await atom.workspace.open('atom://about')
-    aboutElement = workspaceElement.querySelector('.about')
-    updateManager = main.model.state.updateManager
-    scheduler = AboutView.getScheduler()
   })
 
-  describe('when the updates are not supported by the platform', () => {
-    it('hides the auto update UI', async () => {
-      atom.autoUpdater.platformSupportsUpdates.andReturn(false)
-      updateManager.resetState()
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.about-updates')).not.toBeVisible()
-    })
-  })
-
-  describe('when updates are supported by the platform', () => {
+  describe('when the About page is open', () => {
     beforeEach(async () => {
-      atom.autoUpdater.platformSupportsUpdates.andReturn(true)
-      updateManager.resetState()
-      await scheduler.getNextUpdatePromise()
+      jasmine.attachToDOM(workspaceElement)
+      await atom.workspace.open('atom://about')
+      aboutElement = workspaceElement.querySelector('.about')
+      updateManager = main.model.state.updateManager
+      scheduler = AboutView.getScheduler()
     })
 
-    it('shows the auto update UI', () => {
-      expect(aboutElement.querySelector('.about-updates')).toBeVisible()
+    describe('when the updates are not supported by the platform', () => {
+      it('hides the auto update UI', async () => {
+        atom.autoUpdater.platformSupportsUpdates.andReturn(false)
+        updateManager.resetState()
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.about-updates')).not.toBeVisible()
+      })
     })
 
-    it('shows the correct panels when the app checks for updates and there is no update available', async () => {
-      expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+    describe('when updates are supported by the platform', () => {
+      beforeEach(async () => {
+        atom.autoUpdater.platformSupportsUpdates.andReturn(true)
+        updateManager.resetState()
+        await scheduler.getNextUpdatePromise()
+      })
 
-      MockUpdater.checkForUpdate()
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
-      expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
+      it('shows the auto update UI', () => {
+        expect(aboutElement.querySelector('.about-updates')).toBeVisible()
+      })
 
-      MockUpdater.updateNotAvailable()
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-up-to-date')).toBeVisible()
-      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+      it('shows the correct panels when the app checks for updates and there is no update available', async () => {
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+
+        MockUpdater.checkForUpdate()
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
+
+        MockUpdater.updateNotAvailable()
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-up-to-date')).toBeVisible()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+      })
+
+      it('shows the correct panels when the app checks for updates and encounters an error', async () => {
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+
+        MockUpdater.checkForUpdate()
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
+
+        spyOn(atom.autoUpdater, 'getErrorMessage').andReturn('an error message')
+        MockUpdater.updateError()
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-update-error')).toBeVisible()
+        expect(aboutElement.querySelector('.app-error-message').textContent).toBe('an error message')
+        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
+      })
+
+      it('shows the correct panels and button states when the app checks for updates and an update is downloaded', async () => {
+        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
+
+        MockUpdater.checkForUpdate()
+        await scheduler.getNextUpdatePromise()
+
+        expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
+
+        MockUpdater.downloadUpdate()
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
+        // TODO: at some point it would be nice to be able to cancel an update download, and then this would be a cancel button
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
+
+        MockUpdater.finishDownloadingUpdate(42)
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-downloading-update')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
+
+        expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42')
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Restart and install')
+      })
+
+      it('opens the release notes for the downloaded release when the release notes link are clicked', async () => {
+        MockUpdater.finishDownloadingUpdate('1.2.3')
+        await scheduler.getNextUpdatePromise()
+
+        spyOn(shell, 'openExternal')
+        let link = aboutElement.querySelector('.app-update-available-to-install .about-updates-release-notes')
+        link.click()
+
+        let args = shell.openExternal.mostRecentCall.args
+        expect(shell.openExternal).toHaveBeenCalled()
+        expect(args[0]).toContain('/v1.2.3')
+      })
+
+      it('executes checkForUpdate() when the check for update button is clicked', () => {
+        let button = aboutElement.querySelector('.about-update-action-button')
+        button.click()
+        expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled()
+      })
+
+      it('executes restartAndInstallUpdate() when the restart and install button is clicked', async () => {
+        spyOn(atom.autoUpdater, 'restartAndInstallUpdate')
+        MockUpdater.finishDownloadingUpdate(42)
+        await scheduler.getNextUpdatePromise()
+
+        let button = aboutElement.querySelector('.about-update-action-button')
+        button.click()
+        expect(atom.autoUpdater.restartAndInstallUpdate).toHaveBeenCalled()
+      })
+
+      it("starts in the same state as atom's AutoUpdateManager", async () => {
+        atom.autoUpdater.getState.andReturn('downloading')
+        updateManager.resetState()
+
+        await scheduler.getNextUpdatePromise()
+        expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
+        expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
+        expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
+        expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
+      })
+
+      describe('when core.automaticallyUpdate is toggled', () => {
+        beforeEach(async () => {
+          expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
+          atom.autoUpdater.checkForUpdate.reset()
+        })
+
+        it('shows the auto update UI', async () => {
+          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
+          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
+
+          atom.config.set('core.automaticallyUpdate', false)
+          await scheduler.getNextUpdatePromise()
+
+          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
+          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
+        })
+
+        it('updates config and the UI when the checkbox is used to toggle', async () => {
+          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
+
+          aboutElement.querySelector('.about-auto-updates input').click()
+          await scheduler.getNextUpdatePromise()
+
+          expect(atom.config.get('core.automaticallyUpdate')).toBe(false)
+          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
+          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
+
+          aboutElement.querySelector('.about-auto-updates input').click()
+          await scheduler.getNextUpdatePromise()
+
+          expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
+          expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
+          expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
+          expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
+        })
+
+        describe('checking for updates', function () {
+          afterEach(() => {
+            this.updateView = null
+          })
+
+          it('checks for update when the about page is shown', () => {
+            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
+
+            this.updateView = new UpdateView({
+              updateManager: updateManager,
+              availableVersion: '9999.0.0',
+              viewUpdateReleaseNotes: () => {}
+            })
+
+            expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled()
+          })
+
+          it('does not check for update when the about page is shown and the update manager is not in the idle state', () => {
+            atom.autoUpdater.getState.andReturn('downloading')
+            updateManager.resetState()
+            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
+
+            this.updateView = new UpdateView({
+              updateManager: updateManager,
+              availableVersion: '9999.0.0',
+              viewUpdateReleaseNotes: () => {}
+            })
+
+            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
+          })
+
+          it('does not check for update when the about page is shown and auto updates are turned off', () => {
+            atom.config.set('core.automaticallyUpdate', false)
+            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
+
+            this.updateView = new UpdateView({
+              updateManager: updateManager,
+              availableVersion: '9999.0.0',
+              viewUpdateReleaseNotes: () => {}
+            })
+
+            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
+          })
+        })
+      })
     })
+  })
 
-    it('shows the correct panels when the app checks for updates and encounters an error', async () => {
-      expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-
-      MockUpdater.checkForUpdate()
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
-      expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
-
-      spyOn(atom.autoUpdater, 'getErrorMessage').andReturn('an error message')
-      MockUpdater.updateError()
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-update-error')).toBeVisible()
-      expect(aboutElement.querySelector('.app-error-message').textContent).toBe('an error message')
-      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
-      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-    })
-
-    it('shows the correct panels and button states when the app checks for updates and an update is downloaded', async () => {
-      expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
-      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-
-      MockUpdater.checkForUpdate()
-      await scheduler.getNextUpdatePromise()
-
-      expect(aboutElement.querySelector('.app-up-to-date')).not.toBeVisible()
-      expect(aboutElement.querySelector('.app-checking-for-updates')).toBeVisible()
-      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
-      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-
-      MockUpdater.downloadUpdate()
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-      expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
-      // TODO: at some point it would be nice to be able to cancel an update download, and then this would be a cancel button
-      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
-      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-
+  describe('when the About page is not open and an update is downloaded', () => {
+    it('should display the new version when it is opened', async () => {
       MockUpdater.finishDownloadingUpdate(42)
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-downloading-update')).not.toBeVisible()
-      expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
 
+      jasmine.attachToDOM(workspaceElement)
+      await atom.workspace.open('atom://about')
+      aboutElement = workspaceElement.querySelector('.about')
+      updateManager = main.model.state.updateManager
+      scheduler = AboutView.getScheduler()
+
+      expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
       expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42')
       expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
       expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Restart and install')
-    })
-
-    it('opens the release notes for the downloaded release when the release notes link are clicked', async () => {
-      MockUpdater.finishDownloadingUpdate('1.2.3')
-      await scheduler.getNextUpdatePromise()
-
-      spyOn(shell, 'openExternal')
-      let link = aboutElement.querySelector('.app-update-available-to-install .about-updates-release-notes')
-      link.click()
-
-      let args = shell.openExternal.mostRecentCall.args
-      expect(shell.openExternal).toHaveBeenCalled()
-      expect(args[0]).toContain('/v1.2.3')
-    })
-
-    it('executes checkForUpdate() when the check for update button is clicked', () => {
-      let button = aboutElement.querySelector('.about-update-action-button')
-      button.click()
-      expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled()
-    })
-
-    it('executes restartAndInstallUpdate() when the restart and install button is clicked', async () => {
-      spyOn(atom.autoUpdater, 'restartAndInstallUpdate')
-      MockUpdater.finishDownloadingUpdate(42)
-      await scheduler.getNextUpdatePromise()
-
-      let button = aboutElement.querySelector('.about-update-action-button')
-      button.click()
-      expect(atom.autoUpdater.restartAndInstallUpdate).toHaveBeenCalled()
-    })
-
-    it("starts in the same state as atom's AutoUpdateManager", async () => {
-      atom.autoUpdater.getState.andReturn('downloading')
-      updateManager.resetState()
-
-      await scheduler.getNextUpdatePromise()
-      expect(aboutElement.querySelector('.app-checking-for-updates')).not.toBeVisible()
-      expect(aboutElement.querySelector('.app-downloading-update')).toBeVisible()
-      expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
-      expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
-    })
-
-    describe('when core.automaticallyUpdate is toggled', () => {
-      beforeEach(async () => {
-        expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
-        atom.autoUpdater.checkForUpdate.reset()
-      })
-
-      it('shows the auto update UI', async () => {
-        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
-        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
-
-        atom.config.set('core.automaticallyUpdate', false)
-        await scheduler.getNextUpdatePromise()
-
-        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
-        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
-      })
-
-      it('updates config and the UI when the checkbox is used to toggle', async () => {
-        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
-
-        aboutElement.querySelector('.about-auto-updates input').click()
-        await scheduler.getNextUpdatePromise()
-
-        expect(atom.config.get('core.automaticallyUpdate')).toBe(false)
-        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(false)
-        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Automatic updates are disabled please check manually')
-
-        aboutElement.querySelector('.about-auto-updates input').click()
-        await scheduler.getNextUpdatePromise()
-
-        expect(atom.config.get('core.automaticallyUpdate')).toBe(true)
-        expect(aboutElement.querySelector('.about-auto-updates input').checked).toBe(true)
-        expect(aboutElement.querySelector('.about-default-update-message')).toBeVisible()
-        expect(aboutElement.querySelector('.about-default-update-message').textContent).toBe('Atom will check for updates automatically')
-      })
-
-      describe('checking for updates', function () {
-        afterEach(() => {
-          this.updateView = null
-        })
-
-        it('checks for update when the about page is shown', () => {
-          expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
-
-          this.updateView = new UpdateView({
-            updateManager: updateManager,
-            availableVersion: '9999.0.0',
-            viewUpdateReleaseNotes: () => {}
-          })
-
-          expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled()
-        })
-
-        it('does not check for update when the about page is shown and the update manager is not in the idle state', () => {
-          atom.autoUpdater.getState.andReturn('downloading')
-          updateManager.resetState()
-          expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
-
-          this.updateView = new UpdateView({
-            updateManager: updateManager,
-            availableVersion: '9999.0.0',
-            viewUpdateReleaseNotes: () => {}
-          })
-
-          expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
-        })
-
-        it('does not check for update when the about page is shown and auto updates are turned off', () => {
-          atom.config.set('core.automaticallyUpdate', false)
-          expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
-
-          this.updateView = new UpdateView({
-            updateManager: updateManager,
-            availableVersion: '9999.0.0',
-            viewUpdateReleaseNotes: () => {}
-          })
-
-          expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled()
-        })
-      })
     })
   })
 })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is my second attempt to fix #44.  The main problem was that there were two UpdateManager instances in the codebase: one in `main.js`, and the second in `about.js` that was subsequently passed to the necessary Etch components.  When the UpdateManager instance in Main detected an update, it would create the Squirrel tooltip, which when clicked, would instantiate About.  About would then create its _own_ UpdateManager, which would have no clue that an update had been downloaded.  This eventually leads to #44 (since the states are independent of each instance, but the version info isn't).

The fix is to pass the UpdateManager created in Main to About, thus getting rid of the second UpdateManager.

### Alternate Designs

UpdateManager could potentially be refactored so that it must be single-instance (can't remember the exact term for this right now...but basically like `Math`).

### Benefits

See above.

### Possible Drawbacks

I had to do some odd updateManager disposal code when About is deactivated, or else one spec would hard crash, two would timeout, and one would fail.  Did some investigation and it looks like the listeners weren't being set up properly when it got reactivated.  I am unsure if there would be any drawbacks from that disposal code, or if it can be improved.

### Applicable Issues

Fixes #44

@petewalker care to do some more static code analysis? :grin:
A spec is included this time which fails on `master`, but passes on this branch.
Whitespace-insensitive diff (for the specs) is available at https://github.com/atom/about/compare/wl-single-update-manager?w=1.

/cc @damieng (primary package contact) - you may notice that this change is similar to the one I recently did in settings-view.  It's essentially the same fix and rationale behind that one.