### PR TITLE
Clear any stored update state when running a dev channel version

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,7 @@ module.exports = {
     this.createModel()
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
-    if (availableVersion === atom.getVersion()) {
+    if (atom.getReleaseChannel() === 'dev' || availableVersion === atom.getVersion()) {
       window.localStorage.removeItem(AvailableUpdateVersion)
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,7 @@ module.exports = {
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
     if (atom.getReleaseChannel() === 'dev' || availableVersion === atom.getVersion()) {
-      window.localStorage.removeItem(AvailableUpdateVersion)
+      this.clearUpdateState()
     }
 
     this.subscriptions.add(updateManager.onDidChange(() => {
@@ -24,6 +24,10 @@ module.exports = {
         window.localStorage.setItem(AvailableUpdateVersion, updateManager.getAvailableVersion())
         this.showStatusBarIfNeeded()
       }
+    }))
+
+    this.subscriptions.add(atom.commands.add('atom-workspace', 'about:clear-update-state', () => {
+      this.clearUpdateState()
     }))
   },
 
@@ -35,6 +39,10 @@ module.exports = {
       updateManager.dispose()
       updateManager = undefined
     }
+  },
+
+  clearUpdateState () {
+    window.localStorage.removeItem(AvailableUpdateVersion)
   },
 
   consumeStatusBar (statusBar) {


### PR DESCRIPTION
### Description of the Change

If you are running a stable version that downloads an update but do not upgrade to that new version and then build a development version of the application, the squirrel will always show in the status bar until you install a stable version and update it. This change clears the update status whenever you run a dev channel version of Atom.

I also added a command to clear the recorded update state in local storage easily for other situations where the update state gets wedged.

### Alternate Designs

One alternate design would be to not cache the update state in local storage and just always check, but there are too many benefits to caching it and few drawbacks.

Another would be to use IndexedDB to cache the update state which would allow `atom --clear-window-state`, a standard debugging step in the [Atom Flight Manual](http://flight-manual.atom.io), to clear any wedged state instead of relying on a one-off command.

### Benefits

* No pesky squirrel when running a version of the app that can't be updated
* Ability to clear wedged update state

### Possible Drawbacks

Clearing the update state means that if you go back to a stable or beta channel version that does need an update, you'll need to wait for the next update check to be notified. Since the next update check is when you restart the app or four hours, it shouldn't be that big of a problem.

### Applicable Issues

N/A
