### PR TITLE
Show information when platform does not support automatic updates

### DIFF
--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -32,7 +32,7 @@ export default class AboutView extends EtchComponent {
 
   handleHowToUpdateClick (e) {
     e.preventDefault()
-    shell.openExternal('http://flight-manual.atom.io/getting-started/sections/installing-atom/')
+    shell.openExternal('https://flight-manual.atom.io/getting-started/sections/installing-atom/')
   }
 
   render () {

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -30,6 +30,11 @@ export default class AboutView extends EtchComponent {
     shell.openExternal('https://help.github.com/articles/github-terms-of-service')
   }
 
+  handleHowToUpdateClick (e) {
+    e.preventDefault()
+    shell.openExternal('https://github.com/atom/atom#installing')
+  }
+
   render () {
     return (
       <div className='pane-item native-key-bindings about'>
@@ -47,7 +52,7 @@ export default class AboutView extends EtchComponent {
             </div>
           </header>
 
-          <UpdateView updateManager={this.props.updateManager} availableVersion={this.props.availableVersion} viewUpdateReleaseNotes={this.handleReleaseNotesClick.bind(this)} />
+          <UpdateView updateManager={this.props.updateManager} availableVersion={this.props.availableVersion} viewUpdateReleaseNotes={this.handleReleaseNotesClick.bind(this)} viewUpdateInstructions={this.handleHowToUpdateClick.bind(this)} />
 
           <div className='about-actions group-item'>
             <div className='btn-group'>

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -32,7 +32,7 @@ export default class AboutView extends EtchComponent {
 
   handleHowToUpdateClick (e) {
     e.preventDefault()
-    shell.openExternal('https://github.com/atom/atom#installing')
+    shell.openExternal('http://flight-manual.atom.io/getting-started/sections/installing-atom/')
   }
 
   render () {

--- a/lib/components/update-view.js
+++ b/lib/components/update-view.js
@@ -79,7 +79,7 @@ export default class UpdateView extends EtchComponent {
         updateStatus = (
           <div className='about-updates-item app-unsupported'>
             <span className='about-updates-label is-strong'>Your system does not support automatic updates</span>
-            <a className='about-updates-release-notes' onclick={this.props.viewUpdateInstructions}>How to update</a>
+            <a className='about-updates-instructions' onclick={this.props.viewUpdateInstructions}>How to update</a>
           </div>
         )
         break

--- a/lib/components/update-view.js
+++ b/lib/components/update-view.js
@@ -75,6 +75,14 @@ export default class UpdateView extends EtchComponent {
           </div>
         )
         break
+      case UpdateManager.State.Unsupported:
+        updateStatus = (
+          <div className='about-updates-item app-unsupported'>
+            <span className='about-updates-label is-strong'>Your system does not support automatic updates</span>
+            <a className='about-updates-release-notes' onclick={this.props.viewUpdateInstructions}>How to update</a>
+          </div>
+        )
+        break
       case UpdateManager.State.Error:
         updateStatus = (
           <div className='about-updates-item app-update-error'>
@@ -92,20 +100,22 @@ export default class UpdateView extends EtchComponent {
 
   render () {
     return (
-      <div className='about-updates group-start' style={{
-        display: this.props.updateManager.state === UpdateManager.State.Unsupported ? 'none' : 'block'
-      }}>
+      <div className='about-updates group-start'>
         <div className='about-updates-box'>
           <div className='about-updates-status'>
             {this.renderUpdateStatus()}
           </div>
 
-          <button className='btn about-update-action-button' disabled={this.shouldUpdateActionButtonBeDisabled()} onclick={this.executeUpdateAction.bind(this)}>
+          <button className='btn about-update-action-button' disabled={this.shouldUpdateActionButtonBeDisabled()} onclick={this.executeUpdateAction.bind(this)} style={{
+            display: this.props.updateManager.state === UpdateManager.State.Unsupported ? 'none' : 'block'
+          }}>
             {this.props.updateManager.state === 'update-available' ? 'Restart and install' : 'Check now'}
           </button>
         </div>
 
-        <div className='about-auto-updates'>
+        <div className='about-auto-updates' style={{
+          display: this.props.updateManager.state === UpdateManager.State.Unsupported ? 'none' : 'block'
+        }}>
           <label>
             <input className='input-checkbox' type='checkbox' checked={this.props.updateManager.getAutoUpdatesEnabled()} onchange={this.handleAutoUpdateCheckbox.bind(this)} />
             <span>Automatically download updates</span>

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -40,11 +40,25 @@ describe('UpdateView', () => {
     })
 
     describe('when the updates are not supported by the platform', () => {
-      it('hides the auto update UI', async () => {
+      beforeEach(async () => {
         atom.autoUpdater.platformSupportsUpdates.andReturn(false)
         updateManager.resetState()
         await scheduler.getNextUpdatePromise()
-        expect(aboutElement.querySelector('.about-updates')).not.toBeVisible()
+      })
+
+      it('hides the auto update UI and shows the update instructions link', async () => {
+        expect(aboutElement.querySelector('.about-update-action-button')).not.toBeVisible()
+        expect(aboutElement.querySelector('.about-auto-updates')).not.toBeVisible()
+      })
+
+      it('opens the update instructions page when the instructions link is clicked', async () => {
+        spyOn(shell, 'openExternal')
+        let link = aboutElement.querySelector('.app-unsupported .about-updates-instructions')
+        link.click()
+
+        let args = shell.openExternal.mostRecentCall.args
+        expect(shell.openExternal).toHaveBeenCalled()
+        expect(args[0]).toContain('#installing')
       })
     })
 

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -58,7 +58,7 @@ describe('UpdateView', () => {
 
         let args = shell.openExternal.mostRecentCall.args
         expect(shell.openExternal).toHaveBeenCalled()
-        expect(args[0]).toContain('#installing')
+        expect(args[0]).toContain('installing-atom')
       })
     })
 

--- a/styles/about.less
+++ b/styles/about.less
@@ -119,7 +119,8 @@
   margin: 0 .4em;
 }
 
-.about-updates-release-notes {
+.about-updates-release-notes,
+.about-updates-instructions {
   margin: 0 1em 0 1.5em;
 }
 


### PR DESCRIPTION
### Description of the Change

Currently, when on a platform that does not support automatic updates (ie. Linux) the updates section of the About screen is hidden completely. This change leaves the updates section visible, but hides the "Check Now" button and the checkbox at the bottom. Instead, the text informs the user that their system is not supported and provides a link to the Atom Readme, where they can download the latest version.

**Before:**
![before](https://user-images.githubusercontent.com/4625737/31059009-85f33244-a6cb-11e7-80cd-907989695c5a.png)

**After:**
![after](https://user-images.githubusercontent.com/4625737/31059019-95290b3a-a6cb-11e7-91c0-261f4b381863.png)



### Alternate Designs

There are currently at least two ways for Linux users to update Atom besides manually downloading a fresh .deb or .rpm file each time a new version is released:

1. Updating through native Linux tools via the [unofficial Atom PPA](https://launchpad.net/~webupd8team/+archive/ubuntu/atom)
2. By installing the third-party [Atom Updater package](https://github.com/andyrichardson/atom-updater-linux)

Incorporating either of these methods into the About page (or using code similar to Atom Updater) would do much more for the user than a link. However, if major code changes are undesirable for now, my proposed change is still better than nothing.

### Benefits

It is made more clear that automatic updates are not supported on Linux; hopefully this will mean fewer redundant issues on this topic.

### Possible Drawbacks

This does not address the lack of automatic updates (as I understand, these are blocked on [Electron's autoUpdater](https://github.com/electron/electron/blob/master/docs/api/auto-updater.md)). The code will likely have to change again in the future, either when the Electron groundwork is done or some other workaround is implemented.

### Applicable Issues

#38 