### PR TITLE
Fixing display for squirrel icon

### DIFF
--- a/lib/components/about-status-bar.js
+++ b/lib/components/about-status-bar.js
@@ -20,7 +20,9 @@ export default class AboutStatusBar extends EtchComponent {
 
   render () {
     return (
-      <span type='button' className='about-release-notes icon icon-squirrel inline-block' onclick={this.handleClick.bind(this)} />
+      <div className='about-release-notes inline-block' onclick={this.handleClick.bind(this)}>
+        <span type='button' className='icon icon-squirrel' />
+      </div>
     )
   }
 


### PR DESCRIPTION
When there is an update available, the squirrel icon pops up on the status bar. Currently, the HTML causes the top of the highlighted region to not align with the top of the status bar. This PR fixes that.

![before](https://user-images.githubusercontent.com/3392349/37628141-5c418050-2b95-11e8-8564-2346a9cc8c37.PNG)
**Before**

![after](https://user-images.githubusercontent.com/3392349/37628145-5e13dc48-2b95-11e8-8d18-f27b8b73078c.PNG)
**After**
