### PR TITLE
update terms of service link

### DIFF
--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -27,7 +27,7 @@ export default class AboutView extends EtchComponent {
 
   handleTermsOfUseClick (e) {
     e.preventDefault()
-    shell.openExternal('https://help.github.com/articles/github-terms-of-service')
+    shell.openExternal('https://atom.io/terms')
   }
 
   handleHowToUpdateClick (e) {


### PR DESCRIPTION
Atom needs to be using the client apps terms of service, rather than the more general GitHub TOS.  