### PR TITLE
Clear status bar icon if current version is newer than cached update

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,5 @@
 const {CompositeDisposable} = require('atom')
+const semver = require('semver')
 const UpdateManager = require('./update-manager')
 const About = require('./about')
 const StatusBarView = require('./components/about-status-bar')
@@ -15,7 +16,7 @@ module.exports = {
     this.createModel()
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
-    if (atom.getReleaseChannel() === 'dev' || availableVersion === atom.getVersion()) {
+    if (atom.getReleaseChannel() === 'dev' || availableVersion && semver.lte(availableVersion, atom.getVersion())) {
       this.clearUpdateState()
     }
 
@@ -70,7 +71,7 @@ module.exports = {
 
   isUpdateAvailable () {
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
-    return availableVersion && availableVersion !== atom.getVersion()
+    return availableVersion && semver.gt(availableVersion, atom.getVersion())
   },
 
   showStatusBarIfNeeded () {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "atom": ">=1.7 <2.0.0"
   },
   "dependencies": {
-    "etch": "0.9.0"
+    "etch": "0.9.0",
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/spec/about-status-bar-spec.js
+++ b/spec/about-status-bar-spec.js
@@ -46,13 +46,13 @@ describe('the status bar', () => {
 
     describe('with an update', () => {
       it('shows the view when the update finishes downloading', () => {
-        MockUpdater.finishDownloadingUpdate('42')
+        MockUpdater.finishDownloadingUpdate('42.0.0')
         expect(workspaceElement).toContain('.about-release-notes')
       })
 
       describe('clicking on the status', () => {
         it('opens the about page', async () => {
-          MockUpdater.finishDownloadingUpdate('42')
+          MockUpdater.finishDownloadingUpdate('42.0.0')
           workspaceElement.querySelector('.about-release-notes').click()
           await conditionPromise(() => workspaceElement.querySelector('.about'))
           expect(workspaceElement.querySelector('.about')).toExist()
@@ -60,7 +60,7 @@ describe('the status bar', () => {
       })
 
       it('continues to show the squirrel until Atom is updated to the new version', async () => {
-        MockUpdater.finishDownloadingUpdate('42')
+        MockUpdater.finishDownloadingUpdate('42.0.0')
         expect(workspaceElement).toContain('.about-release-notes')
 
         await atom.packages.deactivatePackage('about')
@@ -73,7 +73,19 @@ describe('the status bar', () => {
         await atom.packages.deactivatePackage('about')
         expect(workspaceElement).not.toContain('.about-release-notes')
 
-        atomVersion = '42'
+        atomVersion = '42.0.0'
+        await atom.packages.activatePackage('about')
+
+        await Promise.resolve() // Service consumption hooks are deferred until the next tick
+        expect(workspaceElement).not.toContain('.about-release-notes')
+      })
+
+      it('does not show the view if Atom is updated to a newer version than notified', async () => {
+        MockUpdater.finishDownloadingUpdate('42.0.0')
+
+        await atom.packages.deactivatePackage('about')
+
+        atomVersion = '43.0.0'
         await atom.packages.activatePackage('about')
 
         await Promise.resolve() // Service consumption hooks are deferred until the next tick
@@ -97,13 +109,13 @@ describe('the status bar', () => {
 
     describe('with an update', () => {
       it('shows the view when the update finishes downloading', () => {
-        MockUpdater.finishDownloadingUpdate('42')
+        MockUpdater.finishDownloadingUpdate('42.0.0')
         expect(workspaceElement).toContain('.about-release-notes')
       })
 
       describe('clicking on the status', () => {
         it('opens the about page', async () => {
-          MockUpdater.finishDownloadingUpdate('42')
+          MockUpdater.finishDownloadingUpdate('42.0.0')
           workspaceElement.querySelector('.about-release-notes').click()
           await conditionPromise(() => workspaceElement.querySelector('.about'))
           expect(workspaceElement.querySelector('.about')).toExist()
@@ -111,7 +123,7 @@ describe('the status bar', () => {
       })
 
       it('continues to show the squirrel until Atom is updated to the new version', async () => {
-        MockUpdater.finishDownloadingUpdate('42')
+        MockUpdater.finishDownloadingUpdate('42.0.0')
         expect(workspaceElement).toContain('.about-release-notes')
 
         await atom.packages.deactivatePackage('about')
@@ -124,7 +136,19 @@ describe('the status bar', () => {
         await atom.packages.deactivatePackage('about')
         expect(workspaceElement).not.toContain('.about-release-notes')
 
-        atomVersion = '42'
+        atomVersion = '42.0.0'
+        await atom.packages.activatePackage('about')
+
+        await Promise.resolve() // Service consumption hooks are deferred until the next tick
+        expect(workspaceElement).not.toContain('.about-release-notes')
+      })
+
+      it('does not show the view if Atom is updated to a newer version than notified', async () => {
+        MockUpdater.finishDownloadingUpdate('42.0.0')
+
+        await atom.packages.deactivatePackage('about')
+
+        atomVersion = '43.0.0'
         await atom.packages.activatePackage('about')
 
         await Promise.resolve() // Service consumption hooks are deferred until the next tick
@@ -148,7 +172,7 @@ describe('the status bar', () => {
 
     describe('with a previously downloaded update', () => {
       it('does not show the view', () => {
-        window.localStorage.setItem('about:version-available', '42')
+        window.localStorage.setItem('about:version-available', '42.0.0')
 
         expect(workspaceElement).not.toContain('.about-release-notes')
       })

--- a/spec/update-view-spec.js
+++ b/spec/update-view-spec.js
@@ -126,12 +126,12 @@ describe('UpdateView', () => {
         expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(true)
         expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Check now')
 
-        MockUpdater.finishDownloadingUpdate(42)
+        MockUpdater.finishDownloadingUpdate('42.0.0')
         await scheduler.getNextUpdatePromise()
         expect(aboutElement.querySelector('.app-downloading-update')).not.toBeVisible()
         expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
 
-        expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42')
+        expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42.0.0')
         expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
         expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Restart and install')
       })
@@ -157,7 +157,7 @@ describe('UpdateView', () => {
 
       it('executes restartAndInstallUpdate() when the restart and install button is clicked', async () => {
         spyOn(atom.autoUpdater, 'restartAndInstallUpdate')
-        MockUpdater.finishDownloadingUpdate(42)
+        MockUpdater.finishDownloadingUpdate('42.0.0')
         await scheduler.getNextUpdatePromise()
 
         let button = aboutElement.querySelector('.about-update-action-button')
@@ -265,7 +265,7 @@ describe('UpdateView', () => {
 
   describe('when the About page is not open and an update is downloaded', () => {
     it('should display the new version when it is opened', async () => {
-      MockUpdater.finishDownloadingUpdate(42)
+      MockUpdater.finishDownloadingUpdate('42.0.0')
 
       jasmine.attachToDOM(workspaceElement)
       await atom.workspace.open('atom://about')
@@ -274,7 +274,7 @@ describe('UpdateView', () => {
       scheduler = AboutView.getScheduler()
 
       expect(aboutElement.querySelector('.app-update-available-to-install')).toBeVisible()
-      expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42')
+      expect(aboutElement.querySelector('.app-update-available-to-install .about-updates-version').textContent).toBe('42.0.0')
       expect(aboutElement.querySelector('.about-update-action-button').disabled).toBe(false)
       expect(aboutElement.querySelector('.about-update-action-button').textContent).toBe('Restart and install')
     })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, if an update was found, that version would be stored in local storage and the squirrel icon would be displayed until the current Atom version matched the version in local storage.  Of course, this does not work if the version that Atom is updated to is newer than the one that LocalStorage knows about.  This can happen, for example, when switching from stable to beta.  In that case, About would still insist that there was an update available.

To solve this issue, I have included the `semver` npm package for version checking.  The update state is now cleared if the current Atom version is _greater than or_ equal to the version in LocalStorage.  Similarly, an update is only available if the current Atom version is _less than_ the version in LocalStorage.

New tests have been verified to fail when old behavior is maintained.

### Alternate Designs

Manual string comparisons could be done without bringing in the `semver` dependency.

### Benefits

People who install new versions before the updater realizes they're available will not have a Squirrel icon stuck in their status bar.

### Possible Drawbacks

Slightly longer startup time.

### Applicable Issues

Fixes #50