### PR TITLE
Update Standard and 🔥 babel-eslint

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,7 @@ module.exports = {
     this.createModel()
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion)
-    if (atom.getReleaseChannel() === 'dev' || availableVersion && semver.lte(availableVersion, atom.getVersion())) {
+    if (atom.getReleaseChannel() === 'dev' || (availableVersion && semver.lte(availableVersion, atom.getVersion()))) {
       this.clearUpdateState()
     }
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
-    "standard": "^8.6.0"
+    "standard": "^11.0.0"
   },
   "consumedServices": {
     "status-bar": {
@@ -32,25 +31,14 @@
     "AboutView": "deserializeAboutView"
   },
   "standard": {
-    "ignore": [],
-    "parser": "babel-eslint",
+    "env": [
+      "browser",
+      "node",
+      "atomtest",
+      "jasmine"
+    ],
     "globals": [
-      "atom",
-      "afterEach",
-      "beforeEach",
-      "describe",
-      "fdescribe",
-      "xdescribe",
-      "expect",
-      "it",
-      "fit",
-      "xit",
-      "jasmine",
-      "runs",
-      "spyOn",
-      "waits",
-      "waitsFor",
-      "waitsForPromise"
+      "atom"
     ]
   }
 }


### PR DESCRIPTION
Just some dependency cleanup.  babel-eslint is no longer needed.