### PR TITLE
Adding Additional Information to About Page

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,24 +5,24 @@
 
 ### Description of the Change
 
-<!--
+I've added the information provided via `atom -v` on the command line to the About page, as suggested here: https://github.com/atom/atom/issues/17547
 
-We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+The about page already provides the Atom version, I simply use the process.versions helper to get the Electron and Chrome versions, and the process.version to get the Node version. 
 
--->
+These are shown by clicking a `Show more` link directly below the existing atom version number, and are smaller in order to not clutter up the design. 
 
 ### Alternate Designs
 
-<!-- Explain what other alternates were considered and why the proposed version was selected -->
+I at first just had the new version numbers shown by default directly below the Atom version, in the same font size, and this looked cluttered and busy. I decided since it was extra info and only useful to a subset of people, I'd put it behind a `Show more` button. This prevents cluttering the view, but allows additional useful information if desired. 
 
 ### Benefits
 
-<!-- What benefits will be realized by the code change? -->
+This change will give people the ability to quickly view the current versions of Electron, Chrome and Node being used in their build of Atom without having to open a terminal, and is more discoverable than a terminal command. 
 
 ### Possible Drawbacks
 
-<!-- What are the possible side-effects or negative impacts of the code change? -->
+I haven't noticed any drawbacks in my testing, and no changes in performance of the About page when opening or reloading. It doesn't hide any existing info or add steps to get to existing info, so those who don't need / want the additional version numbers provided won't notice a difference. 
 
 ### Applicable Issues
 
-<!-- Enter any applicable Issues here -->
+n/a

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,24 +5,24 @@
 
 ### Description of the Change
 
-I've added the information provided via `atom -v` on the command line to the About page, as suggested here: https://github.com/atom/atom/issues/17547
+<!--
 
-The about page already provides the Atom version, I simply use the process.versions helper to get the Electron and Chrome versions, and the process.version to get the Node version. 
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
 
-These are shown by clicking a `Show more` link directly below the existing atom version number, and are smaller in order to not clutter up the design. 
+-->
 
 ### Alternate Designs
 
-I at first just had the new version numbers shown by default directly below the Atom version, in the same font size, and this looked cluttered and busy. I decided since it was extra info and only useful to a subset of people, I'd put it behind a `Show more` button. This prevents cluttering the view, but allows additional useful information if desired. 
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
 
 ### Benefits
 
-This change will give people the ability to quickly view the current versions of Electron, Chrome and Node being used in their build of Atom without having to open a terminal, and is more discoverable than a terminal command. 
+<!-- What benefits will be realized by the code change? -->
 
 ### Possible Drawbacks
 
-I haven't noticed any drawbacks in my testing, and no changes in performance of the About page when opening or reloading. It doesn't hide any existing info or add steps to get to existing info, so those who don't need / want the additional version numbers provided won't notice a difference. 
+<!-- What are the possible side-effects or negative impacts of the code change? -->
 
 ### Applicable Issues
 
-n/a
+<!-- Enter any applicable Issues here -->

--- a/lib/about.js
+++ b/lib/about.js
@@ -60,7 +60,10 @@ module.exports = class About {
       this.views.aboutView = new AboutView({
         uri: this.state.uri,
         updateManager: this.state.updateManager,
-        currentVersion: this.state.currentVersion,
+        currentAtomVersion: this.state.currentAtomVersion,
+        currentElectronVersion: this.state.currentElectronVersion,
+        currentChromeVersion: this.state.currentChromeVersion,
+        currentNodeVersion: this.state.currentNodeVersion,
         availableVersion: this.state.updateManager.getAvailableVersion()
       })
       this.handleStateChanges()
@@ -74,7 +77,10 @@ module.exports = class About {
       if (this.views.aboutView) {
         this.views.aboutView.update({
           updateManager: this.state.updateManager,
-          currentVersion: this.state.currentVersion,
+          currentAtomVersion: this.state.currentAtomVersion,
+          currentElectronVersion: this.state.currentElectronVersion,
+          currentChromeVersion: this.state.currentChromeVersion,
+          currentNodeVersion: this.state.currentNodeVersion,
           availableVersion: this.state.updateManager.getAvailableVersion()
         })
       }

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -70,10 +70,10 @@ class AboutView extends EtchComponent {
             $.a({className: 'about-header-release-notes', onclick: this.handleReleaseNotesClick.bind(this)}, 'Release Notes')
           ),
           $.div({className: 'about-more-expand'}),
-          $.span({className: 'about-version-container inline-block show-more', onclick: this.handleShowMoreClick.bind(this)},
+          $.span({className: 'about-version-container inline-block show-more-expand', onclick: this.handleShowMoreClick.bind(this)},
             $.span({className: 'about-more-expand'}, 'Show more')
           ),
-          $.div({id: 'show-more', className: 'hidden'},
+          $.div({id: 'show-more', className: 'show-more hidden about-more-info'},
             $.div({className: 'about-more-info'},
               $.span({className: 'about-version-container inline-block electron', onclick: this.handleElectronVersionClick.bind(this)},
                 $.span({className: 'about-more-version'}, `Electron: ${this.props.currentElectronVersion} `),

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -70,59 +70,59 @@ class AboutView extends EtchComponent {
             $.a({className: 'about-header-release-notes', onclick: this.handleReleaseNotesClick.bind(this)}, 'Release Notes')
           ),
           $.div({className: 'about-more-expand'}),
-            $.span({className: 'about-version-container inline-block show-more', onclick: this.handleShowMoreClick.bind(this)},
-              $.span({className: 'about-more-expand'}, 'Show more'),
-            ),
-            $.div({id: 'show-more', className: 'hidden'},
-              $.div({className: 'about-more-info'},
-                $.span({className: 'about-version-container inline-block electron', onclick: this.handleElectronVersionClick.bind(this)},
-                  $.span({className: 'about-more-version'}, `Electron: ${this.props.currentElectronVersion} `),
-                  $.span({className: 'icon icon-clippy about-copy-version'})
-                ),
-              ),
-              $.div({className: 'about-more-info'},
-                $.span({className: 'about-version-container inline-block chrome', onclick: this.handleChromeVersionClick.bind(this)},
-                  $.span({className: 'about-more-version'}, `Chrome: ${this.props.currentChromeVersion} `),
-                  $.span({className: 'icon icon-clippy about-copy-version'})
-                ),
-              ),
-              $.div({className: 'about-more-info'},
-                $.span({className: 'about-version-container inline-block node', onclick: this.handleNodeVersionClick.bind(this)},
-                  $.span({className: 'about-more-version'}, `Node: ${this.props.currentNodeVersion} `),
-                  $.span({className: 'icon icon-clippy about-copy-version'})
-                ),
-              ),
-            ),
+          $.span({className: 'about-version-container inline-block show-more', onclick: this.handleShowMoreClick.bind(this)},
+            $.span({className: 'about-more-expand'}, 'Show more')
           ),
-        ),
-
-        $(UpdateView, {
-          updateManager: this.props.updateManager,
-          availableVersion: this.props.availableVersion,
-          viewUpdateReleaseNotes: this.handleReleaseNotesClick.bind(this),
-          viewUpdateInstructions: this.handleHowToUpdateClick.bind(this)
-        }),
-
-        $.div({className: 'about-actions group-item'},
-          $.div({className: 'btn-group'},
-            $.button({className: 'btn view-license', onclick: this.handleLicenseClick.bind(this)}, 'License'),
-            $.button({className: 'btn terms-of-use', onclick: this.handleTermsOfUseClick.bind(this)}, 'Terms of Use')
+          $.div({id: 'show-more', className: 'hidden'},
+            $.div({className: 'about-more-info'},
+              $.span({className: 'about-version-container inline-block electron', onclick: this.handleElectronVersionClick.bind(this)},
+                $.span({className: 'about-more-version'}, `Electron: ${this.props.currentElectronVersion} `),
+                $.span({className: 'icon icon-clippy about-copy-version'})
+              )
+            ),
+            $.div({className: 'about-more-info'},
+              $.span({className: 'about-version-container inline-block chrome', onclick: this.handleChromeVersionClick.bind(this)},
+                $.span({className: 'about-more-version'}, `Chrome: ${this.props.currentChromeVersion} `),
+                $.span({className: 'icon icon-clippy about-copy-version'})
+              )
+            ),
+            $.div({className: 'about-more-info'},
+              $.span({className: 'about-version-container inline-block node', onclick: this.handleNodeVersionClick.bind(this)},
+                $.span({className: 'about-more-version'}, `Node: ${this.props.currentNodeVersion} `),
+                $.span({className: 'icon icon-clippy about-copy-version'})
+              )
+            )
           )
-        ),
-
-        $.div({className: 'about-love group-start'},
-          $.span({className: 'icon icon-code'}),
-          $.span({className: 'inline'}, ' with '),
-          $.span({className: 'icon icon-heart'}),
-          $.span({className: 'inline'}, ' by '),
-          $.a({className: 'icon icon-logo-github', href: 'https://github.com'})
-        ),
-
-        $.div({className: 'about-credits group-item'},
-          $.span({className: 'inline'}, 'And the awesome '),
-          $.a({href: 'https://github.com/atom/atom/contributors'}, 'Atom Community')
         )
+      ),
+
+      $(UpdateView, {
+        updateManager: this.props.updateManager,
+        availableVersion: this.props.availableVersion,
+        viewUpdateReleaseNotes: this.handleReleaseNotesClick.bind(this),
+        viewUpdateInstructions: this.handleHowToUpdateClick.bind(this)
+      }),
+
+      $.div({className: 'about-actions group-item'},
+        $.div({className: 'btn-group'},
+          $.button({className: 'btn view-license', onclick: this.handleLicenseClick.bind(this)}, 'License'),
+          $.button({className: 'btn terms-of-use', onclick: this.handleTermsOfUseClick.bind(this)}, 'Terms of Use')
+        )
+      ),
+
+      $.div({className: 'about-love group-start'},
+        $.span({className: 'icon icon-code'}),
+        $.span({className: 'inline'}, ' with '),
+        $.span({className: 'icon icon-heart'}),
+        $.span({className: 'inline'}, ' by '),
+        $.a({className: 'icon icon-logo-github', href: 'https://github.com'})
+      ),
+
+      $.div({className: 'about-credits group-item'},
+        $.span({className: 'inline'}, 'And the awesome '),
+        $.a({href: 'https://github.com/atom/atom/contributors'}, 'Atom Community')
       )
+    )
   }
 
   serialize () {

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -56,12 +56,12 @@ class AboutView extends EtchComponent {
     switch (showMoreText.textContent) {
       case 'Show more':
         showMoreDiv.classList.toggle('hidden')
-        showMoreText.textContent = 'Hide';
-        break;
+        showMoreText.textContent = 'Hide'
+        break
       case 'Hide':
         showMoreDiv.classList.toggle('hidden')
-        showMoreText.textContent = 'Show more';
-        break;
+        showMoreText.textContent = 'Show more'
+        break
     }
   }
 

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -63,31 +63,31 @@ class AboutView extends EtchComponent {
             $(AtomLogo)
           ),
           $.div({className: 'about-header-info'},
-            $.span({className: 'about-version-container inline-block', onclick: this.handleAtomVersionClick.bind(this)},
+            $.span({className: 'about-version-container inline-block atom', onclick: this.handleAtomVersionClick.bind(this)},
               $.span({className: 'about-version'}, `${this.props.currentAtomVersion} ${process.arch}`),
               $.span({className: 'icon icon-clippy about-copy-version'})
             ),
             $.a({className: 'about-header-release-notes', onclick: this.handleReleaseNotesClick.bind(this)}, 'Release Notes')
           ),
           $.div({className: 'about-more-expand'}),
-            $.span({className: 'about-version-container inline-block', onclick: this.handleShowMoreClick.bind(this)},
+            $.span({className: 'about-version-container inline-block show-more', onclick: this.handleShowMoreClick.bind(this)},
               $.span({className: 'about-more-expand'}, 'Show more'),
             ),
             $.div({id: 'show-more', className: 'hidden'},
               $.div({className: 'about-more-info'},
-                $.span({className: 'about-version-container inline-block', onclick: this.handleElectronVersionClick.bind(this)},
+                $.span({className: 'about-version-container inline-block electron', onclick: this.handleElectronVersionClick.bind(this)},
                   $.span({className: 'about-more-version'}, `Electron: ${this.props.currentElectronVersion} `),
                   $.span({className: 'icon icon-clippy about-copy-version'})
                 ),
               ),
               $.div({className: 'about-more-info'},
-                $.span({className: 'about-version-container inline-block', onclick: this.handleChromeVersionClick.bind(this)},
+                $.span({className: 'about-version-container inline-block chrome', onclick: this.handleChromeVersionClick.bind(this)},
                   $.span({className: 'about-more-version'}, `Chrome: ${this.props.currentChromeVersion} `),
                   $.span({className: 'icon icon-clippy about-copy-version'})
                 ),
               ),
               $.div({className: 'about-more-info'},
-                $.span({className: 'about-version-container inline-block', onclick: this.handleNodeVersionClick.bind(this)},
+                $.span({className: 'about-version-container inline-block node', onclick: this.handleNodeVersionClick.bind(this)},
                   $.span({className: 'about-more-version'}, `Node: ${this.props.currentNodeVersion} `),
                   $.span({className: 'icon icon-clippy about-copy-version'})
                 ),

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -51,8 +51,18 @@ class AboutView extends EtchComponent {
 
   handleShowMoreClick (e) {
     e.preventDefault()
-    var more = document.getElementById('show-more')
-    more.classList.toggle('hidden')
+    var showMoreDiv = document.querySelector('.show-more')
+    var showMoreText = document.querySelector('.about-more-expand')
+    switch (showMoreText.textContent) {
+      case 'Show more':
+        showMoreDiv.classList.toggle('hidden')
+        showMoreText.textContent = 'Hide';
+        break;
+      case 'Hide':
+        showMoreDiv.classList.toggle('hidden')
+        showMoreText.textContent = 'Show more';
+        break;
+    }
   }
 
   render () {
@@ -69,11 +79,10 @@ class AboutView extends EtchComponent {
             ),
             $.a({className: 'about-header-release-notes', onclick: this.handleReleaseNotesClick.bind(this)}, 'Release Notes')
           ),
-          $.div({className: 'about-more-expand'}),
           $.span({className: 'about-version-container inline-block show-more-expand', onclick: this.handleShowMoreClick.bind(this)},
             $.span({className: 'about-more-expand'}, 'Show more')
           ),
-          $.div({id: 'show-more', className: 'show-more hidden about-more-info'},
+          $.div({className: 'show-more hidden about-more-info'},
             $.div({className: 'about-more-info'},
               $.span({className: 'about-version-container inline-block electron', onclick: this.handleElectronVersionClick.bind(this)},
                 $.span({className: 'about-more-version'}, `Electron: ${this.props.currentElectronVersion} `),

--- a/lib/components/about-view.js
+++ b/lib/components/about-view.js
@@ -9,9 +9,24 @@ const $ = etch.dom
 
 module.exports =
 class AboutView extends EtchComponent {
-  handleVersionClick (e) {
+  handleAtomVersionClick (e) {
     e.preventDefault()
-    atom.clipboard.write(this.props.currentVersion)
+    atom.clipboard.write(this.props.currentAtomVersion)
+  }
+
+  handleElectronVersionClick (e) {
+    e.preventDefault()
+    atom.clipboard.write(this.props.currentElectronVersion)
+  }
+
+  handleChromeVersionClick (e) {
+    e.preventDefault()
+    atom.clipboard.write(this.props.currentChromeVersion)
+  }
+
+  handleNodeVersionClick (e) {
+    e.preventDefault()
+    atom.clipboard.write(this.props.currentNodeVersion)
   }
 
   handleReleaseNotesClick (e) {
@@ -34,6 +49,12 @@ class AboutView extends EtchComponent {
     shell.openExternal('https://flight-manual.atom.io/getting-started/sections/installing-atom/')
   }
 
+  handleShowMoreClick (e) {
+    e.preventDefault()
+    var more = document.getElementById('show-more')
+    more.classList.toggle('hidden')
+  }
+
   render () {
     return $.div({className: 'pane-item native-key-bindings about'},
       $.div({className: 'about-container'},
@@ -42,12 +63,37 @@ class AboutView extends EtchComponent {
             $(AtomLogo)
           ),
           $.div({className: 'about-header-info'},
-            $.span({className: 'about-version-container inline-block', onclick: this.handleVersionClick.bind(this)},
-              $.span({className: 'about-version'}, `${this.props.currentVersion} ${process.arch}`),
+            $.span({className: 'about-version-container inline-block', onclick: this.handleAtomVersionClick.bind(this)},
+              $.span({className: 'about-version'}, `${this.props.currentAtomVersion} ${process.arch}`),
               $.span({className: 'icon icon-clippy about-copy-version'})
             ),
             $.a({className: 'about-header-release-notes', onclick: this.handleReleaseNotesClick.bind(this)}, 'Release Notes')
-          )
+          ),
+          $.div({className: 'about-more-expand'}),
+            $.span({className: 'about-version-container inline-block', onclick: this.handleShowMoreClick.bind(this)},
+              $.span({className: 'about-more-expand'}, 'Show more'),
+            ),
+            $.div({id: 'show-more', className: 'hidden'},
+              $.div({className: 'about-more-info'},
+                $.span({className: 'about-version-container inline-block', onclick: this.handleElectronVersionClick.bind(this)},
+                  $.span({className: 'about-more-version'}, `Electron: ${this.props.currentElectronVersion} `),
+                  $.span({className: 'icon icon-clippy about-copy-version'})
+                ),
+              ),
+              $.div({className: 'about-more-info'},
+                $.span({className: 'about-version-container inline-block', onclick: this.handleChromeVersionClick.bind(this)},
+                  $.span({className: 'about-more-version'}, `Chrome: ${this.props.currentChromeVersion} `),
+                  $.span({className: 'icon icon-clippy about-copy-version'})
+                ),
+              ),
+              $.div({className: 'about-more-info'},
+                $.span({className: 'about-version-container inline-block', onclick: this.handleNodeVersionClick.bind(this)},
+                  $.span({className: 'about-more-version'}, `Node: ${this.props.currentNodeVersion} `),
+                  $.span({className: 'icon icon-clippy about-copy-version'})
+                ),
+              ),
+            ),
+          ),
         ),
 
         $(UpdateView, {
@@ -77,7 +123,6 @@ class AboutView extends EtchComponent {
           $.a({href: 'https://github.com/atom/atom/contributors'}, 'Atom Community')
         )
       )
-    )
   }
 
   serialize () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -64,7 +64,10 @@ module.exports = {
 
     this.model = new About({
       uri: AboutURI,
-      currentVersion: atom.getVersion(),
+      currentAtomVersion: atom.getVersion(),
+      currentElectronVersion: process.versions.electron,
+      currentChromeVersion: process.versions.chrome,
+      currentNodeVersion: process.version,
       updateManager: updateManager
     })
   },

--- a/spec/about-spec.js
+++ b/spec/about-spec.js
@@ -42,14 +42,58 @@ describe('About', () => {
     })
   })
 
-  describe('when the version number is clicked', () => {
+  describe('when the Atom version number is clicked', () => {
     it('copies the version number to the clipboard', async () => {
       await atom.workspace.open('atom://about')
 
       let aboutElement = workspaceElement.querySelector('.about')
-      let versionContainer = aboutElement.querySelector('.about-version-container')
+      let versionContainer = aboutElement.querySelector('.atom')
       versionContainer.click()
       expect(atom.clipboard.read()).toBe(atom.getVersion())
+    })
+  })
+
+  describe('when the show more link is clicked', () => {
+    it('expands to show additional version numbers', async () => {
+      await atom.workspace.open('atom://about')
+
+      let showMoreElement = workspaceElement.querySelector('.show-more')
+      let moreInfoElement = workspaceElement.querySelector('.show-more-info')
+      showMoreElement.click()
+      expect(moreInfoElement).toBeVisible()
+    })
+  })
+
+  describe('when the Electron version number is clicked', () => {
+    it('copies the version number to the clipboard', async () => {
+      await atom.workspace.open('atom://about')
+
+      let aboutElement = workspaceElement.querySelector('.about')
+      let versionContainer = aboutElement.querySelector('.electron')
+      versionContainer.click()
+      expect(atom.clipboard.read()).toBe(process.versions.electron)
+    })
+  })
+
+  describe('when the Chrome version number is clicked', () => {
+    it('copies the version number to the clipboard', async () => {
+      await atom.workspace.open('atom://about')
+
+      let aboutElement = workspaceElement.querySelector('.about')
+      let versionContainer = aboutElement.querySelector('.chrome')
+      versionContainer.click()
+      expect(atom.clipboard.read()).toBe(process.versions.chrome)
+    })
+  })
+
+  describe('when the Node version number is clicked', () => {
+    it('copies the version number to the clipboard', async () => {
+      await atom.workspace.open('atom://about')
+
+      let aboutElement = workspaceElement.querySelector('.about')
+      let versionContainer = aboutElement.querySelector('.node')
+      versionContainer.click()
+      expect(atom.clipboard.read()).toBe(process.version)
     })
   })
 })

--- a/spec/about-spec.js
+++ b/spec/about-spec.js
@@ -56,9 +56,11 @@ describe('About', () => {
   describe('when the show more link is clicked', () => {
     it('expands to show additional version numbers', async () => {
       await atom.workspace.open('atom://about')
+      jasmine.attachToDOM(workspaceElement)
 
-      let showMoreElement = workspaceElement.querySelector('.show-more')
-      let moreInfoElement = workspaceElement.querySelector('.show-more-info')
+      let aboutElement = workspaceElement.querySelector('.about')
+      let showMoreElement = aboutElement.querySelector('.show-more-expand')
+      let moreInfoElement = workspaceElement.querySelector('.show-more')
       showMoreElement.click()
       expect(moreInfoElement).toBeVisible()
     })

--- a/styles/about.less
+++ b/styles/about.less
@@ -47,6 +47,10 @@
   max-width: 500px;
 }
 
+.hidden {
+  display: none;
+}
+
 
 // Header --------------------------------
 

--- a/styles/about.less
+++ b/styles/about.less
@@ -48,7 +48,7 @@
 }
 
 .hidden {
-  display: none;
+  visibility: hidden;
 }
 
 

--- a/styles/about.less
+++ b/styles/about.less
@@ -47,11 +47,6 @@
   max-width: 500px;
 }
 
-.hidden {
-  visibility: hidden;
-}
-
-
 // Header --------------------------------
 
 .about-atom-io:hover {
@@ -82,6 +77,11 @@
   margin-right: .5em;
   font-size: 1.25em;
   vertical-align: middle;
+}
+
+.about-more-version {
+  color: @text-color-subtle;
+  font-size: .9em;
 }
 
 .about-header-release-notes {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I've added the information provided via `atom -v` on the command line to the About page, as suggested here: https://github.com/atom/atom/issues/17547

The about page already provides the Atom version, I simply use the process.versions helper to get the Electron and Chrome versions, and the process.version to get the Node version. 

These are shown by clicking a `Show more` link directly below the existing atom version number, and are smaller in order to not clutter up the design. 

*Edit by @rsese to drop in before/after screenshots*

Before: 
![before](https://user-images.githubusercontent.com/1477223/42094441-d2d0cea0-7b7d-11e8-8353-7f5e6776d4b9.png)
After, collapsed: 
![after-collapsed](https://user-images.githubusercontent.com/1477223/42094467-e6b80d52-7b7d-11e8-9cfa-078f86c950d2.png)
After, expanded: 
![after-expanded](https://user-images.githubusercontent.com/1477223/42094487-f138292e-7b7d-11e8-86f8-c454a71b3685.png)

### Alternate Designs

I at first just had the new version numbers shown by default directly below the Atom version, in the same font size, and this looked cluttered and busy. I decided since it was extra info and only useful to a subset of people, I'd put it behind a `Show more` button. This prevents cluttering the view, but allows additional useful information if desired. 

### Benefits

This change will give people the ability to quickly view the current versions of Electron, Chrome and Node being used in their build of Atom without having to open a terminal, and is more discoverable than a terminal command. 

### Possible Drawbacks

I haven't noticed any drawbacks in my testing, and no changes in performance of the About page when opening or reloading. It doesn't hide any existing info or add steps to get to existing info, so those who don't need / want the additional version numbers provided won't notice a difference. 

### Applicable Issues

n/a
