### PR TITLE
Use correct repo for nightly channel release notes

### DIFF
--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -127,7 +127,9 @@ let UpdateManager = class UpdateManager {
     if (!appVersion.startsWith('v')) {
       appVersion = `v${appVersion}`
     }
-    return `https://github.com/atom/atom/releases/tag/${appVersion}`
+
+    const releaseRepo = appVersion.indexOf('nightly') > -1 ? 'atom-nightly-releases' : 'atom'
+    return `https://github.com/atom/${releaseRepo}/releases/tag/${appVersion}`
   }
 }
 

--- a/spec/update-manager-spec.js
+++ b/spec/update-manager-spec.js
@@ -16,6 +16,7 @@ describe('UpdateManager', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.7.0')).toContain('atom/atom/releases/tag/v1.7.0')
       expect(updateManager.getReleaseNotesURLForVersion('v1.7.0')).toContain('atom/atom/releases/tag/v1.7.0')
       expect(updateManager.getReleaseNotesURLForVersion('1.7.0-beta10')).toContain('atom/atom/releases/tag/v1.7.0-beta10')
+      expect(updateManager.getReleaseNotesURLForVersion('1.7.0-nightly10')).toContain('atom/atom-nightly-releases/releases/tag/v1.7.0-nightly10')
     })
   })
 })


### PR DESCRIPTION
Nightly releases are hosted at [`atom/atom-nightly-releases`](https://github.com/atom/atom-nightly-releases/releases) so that repo should be consulted for release notes.